### PR TITLE
chore: ensure package name are not included in releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
       "changelog-path": "CHANGELOG.md",
       "release-type": "node",
       "draft": false,
-      "prerelease": false
+      "prerelease": false,
+      "include-component-in-tag": false
     }
   },
   "release-type": "node",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Release-please seems to be looking for tag name with the package name as prefix: `❯ looking for tagName: altinn-components-v0.15.1`

When using simple release strategy, the default name if the package is `.` is empty. But when using the `node`-strategy, it will use whatever is in `.name`-property in the `package.json`. 

By modifying `include-component-in-tag` I assume that it will search for tags without the prefix..

## Related Issue(s)
- #N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
