### PR TITLE
fix: allow use of img url as icon source

### DIFF
--- a/lib/components/AccessAreaList/AccessAreaList.tsx
+++ b/lib/components/AccessAreaList/AccessAreaList.tsx
@@ -10,7 +10,7 @@ export const AccessAreaList = ({ items, color }: AccessAreaListProps) => {
   return (
     <ListBase color={color} spacing={1}>
       {items.map((item) => (
-        <AccessAreaListItem {...item} key={item.id} {...item} />
+        <AccessAreaListItem key={item.id} {...item} />
       ))}
     </ListBase>
   );

--- a/lib/components/AccessAreaList/AccessAreaListItem.stories.tsx
+++ b/lib/components/AccessAreaList/AccessAreaListItem.stories.tsx
@@ -36,7 +36,7 @@ const meta = {
     id: testArea.id,
     size: 'md',
     name: testArea.name,
-    icon: svgStringToComponent(testArea.icon, testArea.name),
+    iconUrl: 'https://www.svgrepo.com/show/457192/home.svg',
     badgeText: '2 of 7',
     colorTheme: 'company',
     loading: false,
@@ -51,11 +51,6 @@ const meta = {
       options: ['sm', 'md', 'lg'],
       control: {
         type: 'inline-radio',
-      },
-    },
-    icon: {
-      control: {
-        disable: true,
       },
     },
     colorTheme: {

--- a/lib/components/AccessAreaList/AccessAreaListItem.tsx
+++ b/lib/components/AccessAreaList/AccessAreaListItem.tsx
@@ -5,15 +5,11 @@ import { ListItem } from '../List';
 import type { ListItemProps } from '../List';
 import styles from './accessAreaListItem.module.css';
 
-export interface AccessAreaListItemProps extends Pick<ListItemProps, 'size' | 'onClick' | 'expanded' | 'loading'> {
+interface AccessAreaListItemDefaultProps extends Pick<ListItemProps, 'size' | 'onClick' | 'expanded' | 'loading'> {
   /** Id of the item */
   id: string;
   /** Name of the Access Area */
   name: string;
-  /** The icon associated with the Access Area */
-  icon?: SvgElement;
-  /** The imgUrl of the icon associated with the Access Area */
-  iconUrl?: string;
   /** Color theme of the Access Area */
   colorTheme?: Color;
   /** Optional Badge to display things like the number of packages a user has in the area */
@@ -21,6 +17,10 @@ export interface AccessAreaListItemProps extends Pick<ListItemProps, 'size' | 'o
   /** Children to render when the item is expanded */
   children?: React.ReactNode;
 }
+
+export type AccessAreaListItemProps =
+  | (AccessAreaListItemDefaultProps & { icon: SvgElement; iconUrl?: never })
+  | (AccessAreaListItemDefaultProps & { iconUrl: string; icon?: never });
 
 export const AccessAreaListItem = ({
   name,

--- a/lib/components/AccessAreaList/AccessAreaListItem.tsx
+++ b/lib/components/AccessAreaList/AccessAreaListItem.tsx
@@ -35,7 +35,13 @@ export const AccessAreaListItem = ({
   loading,
   ...props
 }: AccessAreaListItemProps) => {
-  const themedIcon = { svgElement: icon, iconUrl: iconUrl, theme: 'subtle', color: colorTheme, altText: '' } as IconProps;
+  const themedIcon = {
+    svgElement: icon,
+    iconUrl: iconUrl,
+    theme: 'subtle',
+    color: colorTheme,
+    altText: '',
+  } as IconProps;
   const badge = badgeText ? ({ label: badgeText, color: colorTheme } as BadgeProps) : undefined;
   return (
     <ListItem

--- a/lib/components/AccessAreaList/AccessAreaListItem.tsx
+++ b/lib/components/AccessAreaList/AccessAreaListItem.tsx
@@ -11,7 +11,9 @@ export interface AccessAreaListItemProps extends Pick<ListItemProps, 'size' | 'o
   /** Name of the Access Area */
   name: string;
   /** The icon associated with the Access Area */
-  icon: SvgElement;
+  icon?: SvgElement;
+  /** The imgUrl of the icon associated with the Access Area */
+  iconUrl?: string;
   /** Color theme of the Access Area */
   colorTheme?: Color;
   /** Optional Badge to display things like the number of packages a user has in the area */
@@ -23,6 +25,7 @@ export interface AccessAreaListItemProps extends Pick<ListItemProps, 'size' | 'o
 export const AccessAreaListItem = ({
   name,
   icon,
+  iconUrl,
   size = 'md',
   children,
   expanded = false,
@@ -32,7 +35,7 @@ export const AccessAreaListItem = ({
   loading,
   ...props
 }: AccessAreaListItemProps) => {
-  const themedIcon = { svgElement: icon, theme: 'subtle', color: colorTheme } as IconProps;
+  const themedIcon = { svgElement: icon, iconUrl: iconUrl, theme: 'subtle', color: colorTheme, altText: '' } as IconProps;
   const badge = badgeText ? ({ label: badgeText, color: colorTheme } as BadgeProps) : undefined;
   return (
     <ListItem

--- a/lib/components/Icon/Icon.tsx
+++ b/lib/components/Icon/Icon.tsx
@@ -8,7 +8,8 @@ export type IconColor = Color;
 export type IconTheme = Theme;
 
 export interface IconProps {
-  svgElement: SvgElement | undefined | null | string;
+  svgElement?: SvgElement | undefined | null | string;
+  iconUrl?: string;
   altText?: string;
   loading?: boolean;
   size?: IconSize;
@@ -17,16 +18,35 @@ export interface IconProps {
   className?: string;
 }
 
-export const Icon = ({ loading, altText, svgElement: SvgElement, size, color, theme, className }: IconProps) => {
-  if (!SvgElement) {
-    return <span className={cx([styles.icon], className)} />;
+export const Icon = ({
+  loading,
+  altText,
+  svgElement: SvgElement,
+  size,
+  color,
+  theme,
+  iconUrl,
+  className,
+}: IconProps) => {
+  if (SvgElement) {
+    return (
+      <Skeleton loading={loading} variant="circle">
+        <span data-size={size} data-color={color} data-theme={theme} className={cx([styles.icon], className)}>
+          <SvgElement aria-hidden="true" alt-label={altText} />
+        </span>
+      </Skeleton>
+    );
   }
 
-  return (
-    <Skeleton loading={loading} variant="circle">
-      <span data-size={size} data-color={color} data-theme={theme} className={cx([styles.icon], className)}>
-        <SvgElement aria-hidden="true" alt-label={altText} />
-      </span>
-    </Skeleton>
-  );
+  if (iconUrl) {
+    return (
+      <Skeleton loading={loading} variant="circle">
+        <span data-size={size} data-color={color} data-theme={theme} className={cx([styles.icon], className)}>
+          <img src={iconUrl} alt={altText} className={styles.icon} />
+        </span>
+      </Skeleton>
+    );
+  }
+
+  return <span className={cx([styles.icon], className)} />;
 };

--- a/lib/components/Icon/IconOrAvatar.tsx
+++ b/lib/components/Icon/IconOrAvatar.tsx
@@ -35,7 +35,7 @@ function isReactNode(value: unknown): value is ReactNode {
 }
 
 const isIconProps = (icon: IconProps | SvgElement | ReactNode): icon is IconProps => {
-  return (icon as IconProps).svgElement !== undefined;
+  return (icon as IconProps).svgElement !== undefined || (icon as IconProps).iconUrl !== undefined;
 };
 
 export const IconOrAvatar = ({ size, icon, iconTheme, avatar, avatarGroup }: IconOrAvatarProps) => {

--- a/package.json
+++ b/package.json
@@ -2,17 +2,11 @@
   "name": "@altinn/altinn-components",
   "version": "0.18.1",
   "main": "dist/index.js",
-  "files": [
-    "dist/",
-    "!dist/stories/",
-    "!dist/components/*/*.stories.js"
-  ],
+  "files": ["dist/", "!dist/stories/", "!dist/components/*/*.stories.js"],
   "types": "dist/types/lib/index.d.ts",
   "type": "module",
   "description": "Reusable react components",
-  "sideEffects": [
-    "*.css"
-  ],
+  "sideEffects": ["*.css"],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The use of url as icon source was removed at some point, but this is a necessary feature for Access management as things are now.

Allowed for use of img url as an alternative to svgElement in IconProps


## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
