### PR TITLE
fix: search backgrounds

### DIFF
--- a/lib/components/Search/searchField.module.css
+++ b/lib/components/Search/searchField.module.css
@@ -34,7 +34,7 @@
 }
 
 .input:focus,
-.input[value] {
+.input:not(:placeholder-shown) {
   background-color: var(--ds-color-background-default);
 }
 

--- a/lib/components/Toolbar/toolbarSearch.module.css
+++ b/lib/components/Toolbar/toolbarSearch.module.css
@@ -20,6 +20,7 @@
   border-radius: 2px;
   border: 1px solid;
   border-color: var(--ds-color-border-default);
+  background-color: var(--ds-color-background-default);
 }
 
 .input[type="search"]::-webkit-search-decoration,


### PR DESCRIPTION
toolbar search should always have a background
global search should have background when focused or has value

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
