### PR TITLE
add titleAs prop to ListItem components for customizable header element type

### DIFF
--- a/lib/components/List/ListItem.tsx
+++ b/lib/components/List/ListItem.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement, ReactNode } from 'react';
+import type { ElementType, ReactElement, ReactNode } from 'react';
 import type { AvatarGroupProps, AvatarProps } from '../Avatar';
 import type { BadgeProps } from '../Badge';
 import type { IconProps, SvgElement } from '../Icon';
@@ -14,6 +14,8 @@ export interface ListItemProps extends ListItemBaseProps, ListItemHeaderProps {
   loading?: boolean;
   /** Title */
   title?: string;
+  /** Element type of the list-item header label. Defaults to h2 */
+  titleAs?: ElementType;
   /** Optional description */
   description?: string;
   /** List item icon */
@@ -50,6 +52,7 @@ export const ListItem = ({
   avatar,
   avatarGroup,
   title,
+  titleAs,
   description,
   badge,
   linkIcon = false,
@@ -91,6 +94,7 @@ export const ListItem = ({
         avatarGroup={avatarGroup}
         badge={badge}
         controls={controls}
+        titleAs={titleAs}
         {...rest}
       >
         {applicableLabel}

--- a/lib/components/List/ListItemHeader.tsx
+++ b/lib/components/List/ListItemHeader.tsx
@@ -1,8 +1,4 @@
-import {
-  ChevronDownIcon,
-  ChevronRightIcon,
-  ChevronUpIcon,
-} from '@navikt/aksel-icons';
+import { ChevronDownIcon, ChevronRightIcon, ChevronUpIcon } from '@navikt/aksel-icons';
 
 import cx from 'classnames';
 import { type ElementType, type ReactNode, isValidElement, useId } from 'react';
@@ -117,8 +113,8 @@ export const ListItemHeader = ({
       ? ChevronUpIcon
       : ChevronDownIcon
     : linkIcon
-    ? ChevronRightIcon
-    : undefined;
+      ? ChevronRightIcon
+      : undefined;
 
   /** Set default icon size */
   const applicableIconSize = iconSizeMap[size];
@@ -163,11 +159,7 @@ export const ListItemHeader = ({
         </ListItemLink>
         <div className={styles.content} data-size={size}>
           {select && (
-            <ListItemSelect
-              {...select}
-              className={styles.select}
-              size={applicableIconSize as ListItemIconSize}
-            />
+            <ListItemSelect {...select} className={styles.select} size={applicableIconSize as ListItemIconSize} />
           )}
           <ListItemIcon
             loading={loading}
@@ -193,12 +185,7 @@ export const ListItemHeader = ({
           ) : (
             <>
               {renderBadge()}
-              {applicableIcon && (
-                <Icon
-                  svgElement={applicableIcon}
-                  size={applicableIconSize as ListItemIconSize}
-                />
-              )}
+              {applicableIcon && <Icon svgElement={applicableIcon} size={applicableIconSize as ListItemIconSize} />}
             </>
           )}
         </ListItemControls>

--- a/lib/components/List/ListItemHeader.tsx
+++ b/lib/components/List/ListItemHeader.tsx
@@ -1,7 +1,7 @@
 import { ChevronDownIcon, ChevronRightIcon, ChevronUpIcon } from '@navikt/aksel-icons';
 
 import cx from 'classnames';
-import { ElementType, type ReactNode, isValidElement, useId } from 'react';
+import { type ElementType, type ReactNode, isValidElement, useId } from 'react';
 import {
   type AvatarGroupProps,
   type AvatarProps,

--- a/lib/components/List/ListItemHeader.tsx
+++ b/lib/components/List/ListItemHeader.tsx
@@ -1,4 +1,8 @@
-import { ChevronDownIcon, ChevronRightIcon, ChevronUpIcon } from '@navikt/aksel-icons';
+import {
+  ChevronDownIcon,
+  ChevronRightIcon,
+  ChevronUpIcon,
+} from '@navikt/aksel-icons';
 
 import cx from 'classnames';
 import { type ElementType, type ReactNode, isValidElement, useId } from 'react';
@@ -113,8 +117,8 @@ export const ListItemHeader = ({
       ? ChevronUpIcon
       : ChevronDownIcon
     : linkIcon
-      ? ChevronRightIcon
-      : undefined;
+    ? ChevronRightIcon
+    : undefined;
 
   /** Set default icon size */
   const applicableIconSize = iconSizeMap[size];
@@ -159,7 +163,11 @@ export const ListItemHeader = ({
         </ListItemLink>
         <div className={styles.content} data-size={size}>
           {select && (
-            <ListItemSelect {...select} className={styles.select} size={applicableIconSize as ListItemIconSize} />
+            <ListItemSelect
+              {...select}
+              className={styles.select}
+              size={applicableIconSize as ListItemIconSize}
+            />
           )}
           <ListItemIcon
             loading={loading}
@@ -168,7 +176,14 @@ export const ListItemHeader = ({
             avatar={avatar}
             avatarGroup={avatarGroup}
           />
-          <ListItemLabel size={size} loading={loading} title={title} description={description} id={listItemLabelId} titleAs={titleAs}>
+          <ListItemLabel
+            size={size}
+            loading={loading}
+            title={title}
+            description={description}
+            id={listItemLabelId}
+            titleAs={titleAs}
+          >
             {children}
           </ListItemLabel>
         </div>
@@ -178,7 +193,12 @@ export const ListItemHeader = ({
           ) : (
             <>
               {renderBadge()}
-              {applicableIcon && <Icon svgElement={applicableIcon} size={applicableIconSize as ListItemIconSize} />}
+              {applicableIcon && (
+                <Icon
+                  svgElement={applicableIcon}
+                  size={applicableIconSize as ListItemIconSize}
+                />
+              )}
             </>
           )}
         </ListItemControls>

--- a/lib/components/List/ListItemHeader.tsx
+++ b/lib/components/List/ListItemHeader.tsx
@@ -1,7 +1,7 @@
 import { ChevronDownIcon, ChevronRightIcon, ChevronUpIcon } from '@navikt/aksel-icons';
 
 import cx from 'classnames';
-import { type ReactNode, isValidElement, useId } from 'react';
+import { ElementType, type ReactNode, isValidElement, useId } from 'react';
 import {
   type AvatarGroupProps,
   type AvatarProps,
@@ -47,6 +47,8 @@ export interface ListItemHeaderProps extends ListItemLinkProps {
   linkIcon?: boolean;
   /** Title */
   title?: string;
+  /** Element type of the list-item header label. Defaults to h2*/
+  titleAs?: ElementType;
   /** Description */
   description?: string;
   /** List item icon */
@@ -94,6 +96,7 @@ export const ListItemHeader = ({
   className,
   children,
   ariaLabel,
+  titleAs,
 }: ListItemHeaderProps) => {
   /** Map ListItemSize to ListItemIconSize */
   const iconSizeMap: Record<ListItemSize, ListItemIconSize> = {
@@ -165,7 +168,7 @@ export const ListItemHeader = ({
             avatar={avatar}
             avatarGroup={avatarGroup}
           />
-          <ListItemLabel size={size} loading={loading} title={title} description={description} id={listItemLabelId}>
+          <ListItemLabel size={size} loading={loading} title={title} description={description} id={listItemLabelId} titleAs={titleAs}>
             {children}
           </ListItemLabel>
         </div>

--- a/lib/components/List/ListItemLabel.tsx
+++ b/lib/components/List/ListItemLabel.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { ElementType, ReactNode } from 'react';
 import { Skeleton } from '../Skeleton';
 import type { ListItemSize } from './ListItemBase';
 import styles from './listItemLabel.module.css';
@@ -8,6 +8,7 @@ export interface ListItemLabelProps {
   loading?: boolean;
   size?: ListItemSize;
   title?: string;
+  titleAs?: ElementType;
   weight?: 'bold' | 'normal';
   description?: string;
   children?: ReactNode;
@@ -17,11 +18,13 @@ export const ListItemLabel = ({
   loading = false,
   size = 'sm',
   title,
+  titleAs = 'h2',
   weight = 'bold',
   description,
   children,
   id,
 }: ListItemLabelProps) => {
+  const TitleComponent = titleAs;
   return (
     <span className={styles.label} data-size={size} id={id}>
       {children ? (
@@ -29,9 +32,9 @@ export const ListItemLabel = ({
       ) : (
         <>
           <Skeleton loading={loading}>
-            <h2 className={styles.title} data-size={size} data-weight={weight}>
+            <TitleComponent className={styles.title} data-size={size} data-weight={weight}>
               {title}
-            </h2>
+            </TitleComponent>
           </Skeleton>{' '}
           {description && (
             <Skeleton loading={loading}>


### PR DESCRIPTION

## Description
Add "titleAs" prop in listItem to enable override of heading level

## Related Issue(s)
- #238 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
