### PR TITLE
fix: add titleAs prop to AccessAreaListItem and AccessPackageListItem

### DIFF
--- a/lib/components/AccessAreaList/AccessAreaListItem.tsx
+++ b/lib/components/AccessAreaList/AccessAreaListItem.tsx
@@ -5,7 +5,7 @@ import { ListItem } from '../List';
 import type { ListItemProps } from '../List';
 import styles from './accessAreaListItem.module.css';
 
-interface AccessAreaListItemDefaultProps extends Pick<ListItemProps, 'size' | 'onClick' | 'expanded' | 'loading'> {
+interface AccessAreaListItemDefaultProps extends Pick<ListItemProps, 'size' | 'onClick' | 'expanded' | 'loading' | 'titleAs'> {
   /** Id of the item */
   id: string;
   /** Name of the Access Area */

--- a/lib/components/AccessAreaList/AccessAreaListItem.tsx
+++ b/lib/components/AccessAreaList/AccessAreaListItem.tsx
@@ -5,7 +5,8 @@ import { ListItem } from '../List';
 import type { ListItemProps } from '../List';
 import styles from './accessAreaListItem.module.css';
 
-interface AccessAreaListItemDefaultProps extends Pick<ListItemProps, 'size' | 'onClick' | 'expanded' | 'loading' | 'titleAs'> {
+interface AccessAreaListItemDefaultProps
+  extends Pick<ListItemProps, 'size' | 'onClick' | 'expanded' | 'loading' | 'titleAs'> {
   /** Id of the item */
   id: string;
   /** Name of the Access Area */

--- a/lib/components/AccessPackageList/AccessPackageListItem.tsx
+++ b/lib/components/AccessPackageList/AccessPackageListItem.tsx
@@ -2,7 +2,7 @@ import { PackageIcon } from '@navikt/aksel-icons';
 import { ListItem, type ListItemProps } from '../List';
 
 export interface AccessPackageListItemProps
-  extends Pick<ListItemProps, 'color' | 'onClick' | 'as' | 'title' | 'description' | 'size' | 'controls' | 'loading'> {
+  extends Pick<ListItemProps, 'color' | 'onClick' | 'as' | 'title' | 'description' | 'size' | 'controls' | 'loading' | 'titleAs'> {
   id: string;
 }
 

--- a/lib/components/AccessPackageList/AccessPackageListItem.tsx
+++ b/lib/components/AccessPackageList/AccessPackageListItem.tsx
@@ -2,7 +2,10 @@ import { PackageIcon } from '@navikt/aksel-icons';
 import { ListItem, type ListItemProps } from '../List';
 
 export interface AccessPackageListItemProps
-  extends Pick<ListItemProps, 'color' | 'onClick' | 'as' | 'title' | 'description' | 'size' | 'controls' | 'loading' | 'titleAs'> {
+  extends Pick<
+    ListItemProps,
+    'color' | 'onClick' | 'as' | 'title' | 'description' | 'size' | 'controls' | 'loading' | 'titleAs'
+  > {
   id: string;
 }
 


### PR DESCRIPTION
add titleAs prop to AccessAreaListItem and AccessPackageListItem for customizable header element type

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
