### PR TITLE
fix: Pass interactive prop to ListItemHeader

### DIFF
--- a/lib/components/List/ListItem.tsx
+++ b/lib/components/List/ListItem.tsx
@@ -97,6 +97,7 @@ export const ListItem = ({
         badge={badge}
         controls={controls}
         titleAs={titleAs}
+        interactive={interactive}
         {...rest}
       >
         {applicableLabel}


### PR DESCRIPTION
## Description
`interactive` prop was not passed from ListItem to ListItemHeader (and ListItemHeader sets interactive to true by default), resulting in `cursor: pointer` for non-interactive ListItem

## Related Issue(s)
- this PR

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
