### PR TITLE
fix: gap for virtualized list items is now consistent

### DIFF
--- a/examples/accountMenu.tsx
+++ b/examples/accountMenu.tsx
@@ -12,6 +12,7 @@ export const accountMenu: AccountMenuProps = {
     },
     hidden: false,
   },
+  isVirtualized: false,
   accountGroups: {
     primary: {
       title: 'Deg selv og favoritter',
@@ -49,6 +50,15 @@ export const accountMenu: AccountMenuProps = {
       name: 'Sportsklubben Brann',
       badge: {
         label: '34',
+      },
+    },
+    {
+      id: 'party:daily-pot',
+      groupId: 'favourites',
+      type: 'company',
+      name: 'Daily Pot',
+      badge: {
+        label: '12',
       },
     },
     {

--- a/lib/components/Layout/Layout.stories.tsx
+++ b/lib/components/Layout/Layout.stories.tsx
@@ -31,14 +31,16 @@ export default meta;
 export const Preview = (args: LayoutProps) => {
   const search: SearchbarProps = useInboxSearch(args.header!.search!);
   const menu: GlobalMenuProps = useAccountMenu(args.header!.menu!);
-
   return (
     <Layout
       {...args}
       header={{
         ...args.header,
         currentAccount: menu.currentAccount,
-        menu: menu,
+        menu: {
+          ...menu,
+          isVirtualized: false,
+        },
         search: search,
       }}
     />

--- a/lib/components/Menu/MenuItemsVirtual.tsx
+++ b/lib/components/Menu/MenuItemsVirtual.tsx
@@ -67,11 +67,8 @@ export const MenuItemsVirtual = ({
 
   const virtualizer = useVirtualizer({
     count: flatMenu.length,
-    estimateSize: (index) => {
-      const entry = flatMenu[index];
-      if (!entry) return 0;
-      if (entry.type === 'title') return 44;
-      if (entry.type === 'separator') return 1;
+    gap: 8,
+    estimateSize: () => {
       return 44;
     },
     getScrollElement: () => scrollRef.current,

--- a/lib/components/Menu/menuBase.module.css
+++ b/lib/components/Menu/menuBase.module.css
@@ -3,7 +3,6 @@
   padding: 0;
   margin: 0;
   text-indent: 0;
-
   display: flex;
   flex-direction: column;
 

--- a/lib/components/Menu/menuItemsVirtual.module.css
+++ b/lib/components/Menu/menuItemsVirtual.module.css
@@ -9,3 +9,7 @@
   left: 0;
   width: 100%;
 }
+
+.virtualMenuListItem > * {
+  margin: 0;
+}


### PR DESCRIPTION
I suggest clearing the margin on sub elements for virtual elements and using the `gap` prop in `useVirtualizer `.
We do not need to provide a height since this is measured and we are not setting the height as inline-style.


## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- https://github.com/Altinn/altinn-components/issues/370

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
