### PR TITLE
fix: optionGroups not passed to ToolbarFilter

### DIFF
--- a/lib/components/Toolbar/Toolbar.tsx
+++ b/lib/components/Toolbar/Toolbar.tsx
@@ -123,6 +123,7 @@ export const Toolbar = ({
             removable={item.removable}
             getSelectedLabel={getFilterLabel}
             buttonAltText={removeButtonAltText}
+            optionGroups={item.optionGroups}
           />
         );
       })}


### PR DESCRIPTION
OptionGroups prop was ignored

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
