### PR TITLE
fix: account stories

### DIFF
--- a/examples/accounts/getAccount.tsx
+++ b/examples/accounts/getAccount.tsx
@@ -100,10 +100,11 @@ export const getAccountItem = ({
 
   const getAccountDescription = () => {
     if (type === "company" && parentId) {
-      return "Org. nr: " + uniqueId + " →  Underenhet";
+      const parentAccount = accounts.find((a) => a.id === parentId);
+
+      return "Org. nr: " + uniqueId + ", del av " + parentAccount?.name;
 
       /*
-      const parentAccount = accounts.find((a) => a.id === parentId);
       return (
         "Org. nr: " + uniqueId + " →  Underenhet av " + parentAccount?.uniqueId
       );*/

--- a/lib/components/Account/Account.mdx
+++ b/lib/components/Account/Account.mdx
@@ -1,25 +1,48 @@
 import { Meta, Controls, Primary, Canvas } from "@storybook/blocks";
-import { Flex, HeaderButton } from "../";
+import * as AccountStories from "./Account.stories";
 import * as AccountMenuStories from "./AccountMenu.stories";
+import * as HeaderStories from "../Header/Header.stories";
+import * as GlobalMenuStories from "../GlobalMenu/GlobalMenu.stories";
+import * as ToolbarStories from "../Toolbar/Toolbar.stories";
 
 <Meta title="Account" />
 
-# Account
+# The Account
 
-WORK IN PROGRESS!
+An `Account` is a representation of a person or a company. Signing in will give access to your personal account.
 
-An account is
+Depending on role and privileges granted by others, a user might have access to multiple accounts, both companies and other people.
+
+To distinguish between different people and companies, accounts are followed by a unique `Avatar`. People accounts use light coloured circles, while companies use dark coloured squares.
+
+## Signing in
+
+Before signing in, the `GlobalMenuButton` will display a padlock, indicating that the user should login.
+
+<Canvas of={AccountStories.Login} />
 
 ## Current account
 
-The current end user is presented using an avatar in the Header.
+User is signed in to their personal account. The current account avatar is displayed in the `GlobalMenuButton`.
 
-## AccountMenu
+<Canvas of={AccountStories.CurrentAccount} />
 
-The account menu is used to switch between accounts. It can be accessed from the global menu, or via a toolbar for easy access in context.
+User is signed in on behalf of a company. The company avatar is displayed in the `GlobalMenuButton`.
+
+<Canvas of={AccountStories.CompanyAccount} />
+
+## Global menu
+
+The `GlobalMenu` follows the current account, giving access to different parts of the application. Personal settings should allways be available, even when representing someone else.
+
+<Canvas of={GlobalMenuStories.CompanyAccount} />
+
+## Switching accounts
+
+The `AccountMenu` is used to switch between accounts. It can be accessed from the `GlobalMenu` or in context where appropriate.
 
 <Canvas of={AccountMenuStories.Default} />
 
-### AccountMenu in Header
+In some cases, where switching accounts is a primary tasks, the accountMenu can be included in context, using the `Toolbar`.
 
-### AccountMenu in Toolbar
+<Canvas of={ToolbarStories.WithAccountMenu} />

--- a/lib/components/Account/Account.stories.tsx
+++ b/lib/components/Account/Account.stories.tsx
@@ -1,0 +1,41 @@
+import { type Account, Flex, GlobalMenuButton, Menu } from '..';
+import { defaultAccounts, useAccountMenu } from '../../../examples';
+
+const meta = {
+  title: 'Account',
+  parameters: {},
+};
+
+export default meta;
+
+export const CurrentAccount = () => {
+  const accountList = useAccountMenu({ accounts: defaultAccounts });
+  const currentAccount = accountList?.items[0] as Account;
+
+  return (
+    <Flex spacing={2} align="center">
+      <Menu items={[{ ...currentAccount, size: 'lg' }]} />
+      <GlobalMenuButton currentAccount={currentAccount} />
+    </Flex>
+  );
+};
+
+export const CompanyAccount = () => {
+  const accountList = useAccountMenu({ accounts: defaultAccounts });
+  const currentAccount = accountList?.items[1] as Account;
+
+  return (
+    <Flex spacing={2} align="center">
+      <Menu items={[{ ...currentAccount, size: 'lg' }]} />
+      <GlobalMenuButton currentAccount={currentAccount} />
+    </Flex>
+  );
+};
+
+export const Login = () => {
+  return (
+    <Flex spacing={2} align="center">
+      <GlobalMenuButton />
+    </Flex>
+  );
+};

--- a/lib/components/Account/AccountMenu.stories.tsx
+++ b/lib/components/Account/AccountMenu.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { AccountMenu, type AccountMenuProps } from '..';
-import { accountMenu, defaultAccounts, useAccountMenu } from '../../../examples';
+import { AccountMenu, type AccountMenuProps, Heading, PageBase, Toolbar } from '..';
+import { accountMenu, defaultAccounts, useAccountList, useAccountMenu } from '../../../examples';
 
 const meta = {
   title: 'Account/AccountMenu',
@@ -42,4 +42,26 @@ export const WithGroups: Story = {
   args: {
     items: accountMenu.items as AccountMenuProps['items'],
   },
+};
+
+export const WithToolbar = () => {
+  const { toolbar, items, groups } = useAccountList({
+    accounts: defaultAccounts,
+  });
+
+  const menuItems = items?.map((item) => {
+    return {
+      ...item,
+      collapsible: false,
+      linkIcon: true,
+    };
+  }) as AccountMenuProps['items'];
+
+  return (
+    <PageBase>
+      <Heading>Velg aktør før du går videre</Heading>
+      <Toolbar {...toolbar} />
+      {items && <AccountMenu groups={groups} items={menuItems} />}
+    </PageBase>
+  );
 };

--- a/lib/components/Button/ButtonIcon.tsx
+++ b/lib/components/Button/ButtonIcon.tsx
@@ -16,7 +16,7 @@ import {
 import styles from './buttonIcon.module.css';
 
 export interface ButtonIconProps {
-  icon?: IconProps | SvgElement | AvatarProps | AvatarGroupProps;
+  icon?: IconProps | SvgElement | AvatarProps | AvatarGroupProps | ReactNode;
   iconAltText?: string;
   size?: ButtonSize;
   altText?: string;
@@ -36,7 +36,7 @@ function isReactNode(value: unknown): value is ReactNode {
 export const ButtonIcon = ({ icon, size, iconAltText, className }: ButtonIconProps) => {
   return (
     <span className={cx(styles.wrapper, className)} data-size={size} aria-label={iconAltText}>
-      {(isAvatarProps(icon) && <Avatar {...icon} />) ||
+      {(isAvatarProps(icon) && <Avatar {...icon} className={styles.avatar} />) ||
         (isAvatarGroupProps(icon) && <AvatarGroup {...icon} className={styles.avatarGroup} />) ||
         (isIconProps(icon) && <Icon {...(icon as IconProps)} className={styles.icon} />) ||
         (isReactNode(icon) && icon) || <Icon svgElement={icon as SvgElement} className={styles.icon} />}

--- a/lib/components/Button/buttonIcon.module.css
+++ b/lib/components/Button/buttonIcon.module.css
@@ -1,4 +1,4 @@
-.icon {
+.wrapper {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -27,4 +27,12 @@
   width: 1em;
   height: 1em;
   font-size: 1.5em;
+}
+
+.avatar {
+  font-size: 1.5em;
+}
+
+.avatarGroup {
+  font-size: 1.125em;
 }

--- a/lib/components/GlobalMenu/CurrentAccount.tsx
+++ b/lib/components/GlobalMenu/CurrentAccount.tsx
@@ -1,5 +1,3 @@
-import { ChevronRightIcon } from '@navikt/aksel-icons';
-import { Button } from '../Button';
 import { MenuItem } from '../Menu';
 
 export type Account = {
@@ -13,25 +11,19 @@ export type CurrentAccountProps = {
   account: Account;
   description?: string;
   as?: 'button' | 'div';
-  linkText?: string;
   onClick?: () => void;
   multipleAccounts?: boolean;
 };
 
-export const CurrentAccount = ({ account, as, onClick, linkText }: CurrentAccountProps) => {
+export const CurrentAccount = ({ account, multipleAccounts, as, onClick }: CurrentAccountProps) => {
   return (
     <MenuItem
       id="account"
       size="lg"
-      as={as}
+      interactive={!!multipleAccounts}
+      as={!multipleAccounts ? 'div' : as}
       onClick={onClick}
-      controls={
-        linkText && (
-          <Button as="div" icon={ChevronRightIcon} reverse variant="outline" size="xs">
-            {linkText}
-          </Button>
-        )
-      }
+      linkIcon={multipleAccounts}
       icon={{
         name: account.name,
         type: account.type,

--- a/lib/components/GlobalMenu/GlobalMenu.stories.tsx
+++ b/lib/components/GlobalMenu/GlobalMenu.stories.tsx
@@ -17,7 +17,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default = (args: GlobalMenuProps) => {
+export const CurrentAccount = (args: GlobalMenuProps) => {
   const accounts = args?.accountMenu?.items!;
   const [currentAccount, setCurrentAccount] = useState<Account>(accounts[0] as Account);
 

--- a/lib/components/GlobalMenu/GlobalMenu.tsx
+++ b/lib/components/GlobalMenu/GlobalMenu.tsx
@@ -26,7 +26,6 @@ export const GlobalMenu = ({
   accountMenu,
   items = [],
   groups,
-  changeLabel = 'Change',
   backLabel = 'Back',
   currentAccount,
   currentEndUserLabel = 'Signed in',
@@ -86,7 +85,6 @@ export const GlobalMenu = ({
       <GlobalMenuBase color={currentAccount?.type}>
         <CurrentAccount
           account={currentAccount}
-          linkText={changeLabel}
           multipleAccounts={multipleAccounts}
           as={multipleAccounts ? 'button' : 'div'}
           onClick={multipleAccounts ? onToggleAccounts : undefined}

--- a/lib/components/GlobalMenu/GlobalMenuButton.stories.tsx
+++ b/lib/components/GlobalMenu/GlobalMenuButton.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { type Account, GlobalMenuButton } from '../';
+import { defaultAccounts } from '../../../examples';
+
+const meta = {
+  title: 'Layout/GlobalMenuButton',
+  component: GlobalMenuButton,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    currentAccount: defaultAccounts[0] as Account,
+  },
+} satisfies Meta<typeof GlobalMenuButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Login: Story = {
+  args: {
+    currentAccount: undefined,
+  },
+};
+
+export const Person: Story = {
+  args: {
+    currentAccount: defaultAccounts[0] as Account,
+  },
+};
+
+export const Company: Story = {
+  args: {
+    currentAccount: defaultAccounts[1] as Account,
+    badge: {
+      color: 'alert',
+      label: '2',
+    },
+  },
+};
+
+export const Expanded: Story = {
+  args: {
+    expanded: true,
+  },
+};

--- a/lib/components/GlobalMenu/GlobalMenuButton.tsx
+++ b/lib/components/GlobalMenu/GlobalMenuButton.tsx
@@ -1,0 +1,60 @@
+import { PadlockLockedIcon, XMarkIcon } from '@navikt/aksel-icons';
+import cx from 'classnames';
+import type { ElementType } from 'react';
+import { type Account, ButtonBase, ButtonIcon, ButtonLabel, type ButtonProps } from '../';
+import { Badge, type BadgeProps } from '../Badge';
+
+import styles from './globalMenuButton.module.css';
+
+export interface GlobalMenuButtonProps extends ButtonProps {
+  currentAccount?: Account;
+  label?: string;
+  as?: ElementType;
+  className?: string;
+  expanded?: boolean;
+  badge?: BadgeProps | undefined;
+  tabIndex?: number;
+}
+
+export const GlobalMenuButton = ({
+  className,
+  as = 'button',
+  color = 'accent',
+  variant = 'solid',
+  currentAccount,
+  expanded,
+  label = 'Menu',
+  badge,
+  ...buttonProps
+}: GlobalMenuButtonProps) => {
+  if (expanded) {
+    return (
+      <ButtonBase {...buttonProps} as={as} variant={variant} color={color} className={cx(styles.button, className)}>
+        <ButtonLabel>{label}</ButtonLabel>
+        <ButtonIcon className={styles.closeIcon} icon={<XMarkIcon className={styles.icon} aria-label="Close Icon" />} />
+        {badge && <Badge {...badge} className={styles.badge} />}
+      </ButtonBase>
+    );
+  }
+
+  if (currentAccount) {
+    return (
+      <ButtonBase {...buttonProps} as={as} variant={variant} color={color} className={cx(styles.button, className)}>
+        <ButtonLabel>{label}</ButtonLabel>
+        <ButtonIcon className={styles.avatar} icon={{ type: currentAccount.type, name: currentAccount.name }} />
+        {badge && <Badge {...badge} className={styles.badge} />}
+      </ButtonBase>
+    );
+  }
+
+  return (
+    <ButtonBase {...buttonProps} as={as} variant={variant} color={color} className={cx(styles.button, className)}>
+      <ButtonLabel>{label}</ButtonLabel>
+      <ButtonIcon
+        className={styles.loginIcon}
+        icon={<PadlockLockedIcon className={styles.icon} aria-label="Login Icon" />}
+      />
+      {badge && <Badge {...badge} className={styles.badge} />}
+    </ButtonBase>
+  );
+};

--- a/lib/components/GlobalMenu/globalMenuButton.module.css
+++ b/lib/components/GlobalMenu/globalMenuButton.module.css
@@ -1,0 +1,43 @@
+.button {
+  flex-shrink: 0;
+  position: relative;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  column-gap: 0.625rem;
+  padding: 0.625rem;
+  border: none;
+  border-radius: 4px;
+}
+
+.label {
+  font-size: 1.125rem;
+  font-weight: 500;
+  padding: 0.25rem;
+}
+
+.loginIcon,
+.closeIcon,
+.avatar {
+  font-size: 1.5rem;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 2px;
+}
+
+.loginIcon {
+  background-color: white;
+  color: black;
+}
+
+.closeIcon {
+  outline: 1px solid white;
+}
+
+.badge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  margin-top: -0.75rem;
+  margin-right: -0.75rem;
+}

--- a/lib/components/GlobalMenu/index.tsx
+++ b/lib/components/GlobalMenu/index.tsx
@@ -1,5 +1,6 @@
 export * from './CurrentAccount';
-export * from './GlobalMenu';
 export * from './BackButton';
 export * from './LogoutButton';
 export * from './EndUserLabel';
+export * from './GlobalMenu';
+export * from './GlobalMenuButton';

--- a/lib/components/Header/Header.stories.tsx
+++ b/lib/components/Header/Header.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta } from '@storybook/react';
-import { type GlobalMenuProps, Header, type HeaderProps } from '../';
+import { type Account, type GlobalMenuProps, Header, type HeaderProps } from '../';
 import { header, inboxMenu, useHeader } from '../../../examples';
 
 const meta = {
@@ -31,8 +31,9 @@ export const CurrentAccount = (args: HeaderProps) => {
 };
 
 export const CompanyAccount = (args: HeaderProps) => {
-  const header = useHeader({ ...args, accountId: 'company' });
-  return <Header {...(header as HeaderProps)} />;
+  const header = useHeader({ ...args });
+  const currentAccount = header?.menu?.accountMenu?.items[1] as Account;
+  return <Header {...(header as HeaderProps)} currentAccount={currentAccount} />;
 };
 
 export const SubmenuExpanded = (args: HeaderProps) => {

--- a/lib/components/Header/Header.tsx
+++ b/lib/components/Header/Header.tsx
@@ -1,13 +1,12 @@
 'use client';
 import type { BadgeProps } from '../Badge';
 import { DrawerBase, DropdownBase } from '../Dropdown';
-import { GlobalMenu, type GlobalMenuProps } from '../GlobalMenu';
+import { GlobalMenu, GlobalMenuButton, type GlobalMenuProps } from '../GlobalMenu';
 import type { Account } from '../GlobalMenu';
 import { useRootContext } from '../RootProvider';
 import { Searchbar, type SearchbarProps } from '../Searchbar';
 import { LocaleButton, LocaleSwitcher, type LocaleSwitcherProps } from './';
 import { HeaderBase } from './HeaderBase';
-import { HeaderButton } from './HeaderButton';
 import { HeaderGroup } from './HeaderGroup';
 import { HeaderLogo, type HeaderLogoProps } from './HeaderLogo';
 import { HeaderSearch } from './HeaderSearch';
@@ -56,16 +55,9 @@ export const Header = ({ menu, locale, search, currentAccount, logo = {}, badge 
           </div>
         )}
         <div className={styles.relative}>
-          <HeaderButton
-            color="company"
-            variant="solid"
+          <GlobalMenuButton
             badge={badge}
-            avatar={
-              currentAccount && {
-                type: currentAccount.type,
-                name: currentAccount.name,
-              }
-            }
+            currentAccount={currentAccount}
             onClick={onToggleMenu}
             expanded={currentId === 'menu'}
             label={menu?.menuLabel}

--- a/lib/components/Menu/MenuItem.tsx
+++ b/lib/components/Menu/MenuItem.tsx
@@ -19,6 +19,7 @@ export interface MenuItemProps {
   id: string;
   type?: string;
   tabIndex?: number;
+  interactive?: boolean;
   as?: ElementType;
   size?: MenuItemSize;
   color?: MenuItemColor;

--- a/lib/components/Menu/MenuItemBase.tsx
+++ b/lib/components/Menu/MenuItemBase.tsx
@@ -8,6 +8,7 @@ export type MenuItemSize = 'sm' | 'md' | 'lg';
 export type MenuItemTheme = 'default' | 'subtle' | 'surface' | 'base';
 
 export interface MenuItemBaseProps {
+  interactive?: boolean;
   as?: ElementType;
   color?: MenuItemColor;
   theme?: MenuItemTheme;
@@ -26,6 +27,7 @@ export interface MenuItemBaseProps {
 }
 
 export const MenuItemBase = ({
+  interactive = true,
   as,
   color,
   theme,
@@ -46,6 +48,7 @@ export const MenuItemBase = ({
     <Component
       tabIndex={disabled ? '-1' : (tabIndex ?? 0)}
       className={cx(styles.item, className)}
+      data-interactive={interactive}
       data-size={size}
       data-color={color}
       data-theme={theme}

--- a/lib/components/Menu/MenuItemLabel.tsx
+++ b/lib/components/Menu/MenuItemLabel.tsx
@@ -95,7 +95,9 @@ export const MenuItemLabel = ({ className, size = 'sm', title, badge, descriptio
               {badge && <Badge {...badge} />}
             </Heading>
           )}
-          {descriptionProps && <Heading {...descriptionProps} size={descriptionProps.size || 'xxs'} />}
+          {descriptionProps && (
+            <Heading {...descriptionProps} size={descriptionProps.size || size === 'lg' ? 'xs' : 'xxs'} />
+          )}
         </>
       )}
     </span>

--- a/lib/components/Menu/menuItemBase.module.css
+++ b/lib/components/Menu/menuItemBase.module.css
@@ -58,6 +58,14 @@
   background-color: transparent;
 }
 
+.item {
+  pointer-events: none;
+}
+
+.item[data-interactive="true"] {
+  pointer-events: all;
+}
+
 /* subtle bg */
 
 [data-theme="subtle"] .item:hover {


### PR DESCRIPTION
Account stories explaining the relationship between current account, global menu and swithcing accounts.

- Fixes to GlobalMenu and Header stories.
- Fixes to ButtonIcon
- Rename HeaderButton to GlobalMenuButton and simplify styles
- Add interactive prop to MenuItem to use for single accounts.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
