### PR TITLE
feat: Banner only showing 'X' if a onClose prop is provided

### DIFF
--- a/lib/components/Banner/Banner.stories.tsx
+++ b/lib/components/Banner/Banner.stories.tsx
@@ -23,6 +23,14 @@ export const Default: Story = {
   args: {},
 };
 
+export const WithoutCloseButton = () => {
+  return (
+    <Flex direction="col" spacing={3}>
+      <Banner text="Dette banneret har ingen lukke-knapp" />
+    </Flex>
+  );
+};
+
 export const Colors = (args: BannerProps) => {
   const colors = Object.keys(BannerColorEnum) as BannerColor[];
 

--- a/lib/components/Banner/Banner.tsx
+++ b/lib/components/Banner/Banner.tsx
@@ -39,13 +39,15 @@ export const Banner = ({ closeTitle = 'close', onClose, text, color, sticky = tr
         <InformationSquareIcon className={styles.infoIcon} aria-hidden />
         <span>{text}</span>
       </div>
-      <IconButton
-        icon={XMarkIcon}
-        variant="solid"
-        onClick={onClose}
-        className={styles.dismiss}
-        iconAltText={closeTitle}
-      />
+      {!!onClose && (
+        <IconButton
+          icon={XMarkIcon}
+          variant="solid"
+          onClick={onClose}
+          className={styles.dismiss}
+          iconAltText={closeTitle}
+        />
+      )}
     </section>
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<img width="2190" height="516" alt="CleanShot 2025-07-15 at 10 34 39@2x" src="https://github.com/user-attachments/assets/97bd9c54-97c6-4b7d-9141-0d94c6cb4e9e" />

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #1743

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
