### PR TITLE
fix: 2358, context menu not working for specific dialog

### DIFF
--- a/lib/components/ContextMenu/ContextMenu.tsx
+++ b/lib/components/ContextMenu/ContextMenu.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { MenuElipsisHorizontalIcon } from '@navikt/aksel-icons';
 import cx from 'classnames';
-import { useMemo, useRef } from 'react';
+import { useRef } from 'react';
 import { DropdownBase, type DropdownPlacement, IconButton, type MenuItemProps } from '../';
 import { type MenuItemGroups, MenuItems } from '../';
 import { useClickOutside } from '../../hooks';
@@ -35,17 +35,15 @@ export const ContextMenu = ({
     }
   });
 
-  const itemsWithToggle = useMemo(() => {
-    return items.map((item) => {
-      return {
-        ...item,
-        onClick: () => {
-          item.onClick?.();
-          closeAll();
-        },
-      };
-    });
-  }, [items, closeAll]);
+  const itemsWithToggle = items.map((item) => {
+    return {
+      ...item,
+      onClick: () => {
+        item.onClick?.();
+        closeAll();
+      },
+    };
+  });
 
   return (
     <div className={cx(styles.toggle, className)} data-color="neutral" ref={ref}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Testing suspect: 
The useMemo in ContextMenu was caching the itemsWithToggle array using only items, and closeAll as dependencies, onClick functions inside the items might have stale closures.

## Related Issue(s)

https://github.com/Altinn/dialogporten-frontend/issues/2358

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
