### PR TITLE
fix(storybook): add custom theme and set brand title to include name and version of library

### DIFF
--- a/.storybook/altinn.ts
+++ b/.storybook/altinn.ts
@@ -1,0 +1,8 @@
+import { create } from 'storybook/theming';
+import { version } from '../package.json';
+
+export default create({
+    base: 'light',
+    brandTitle: `Altinn components v${version}`,
+    fontBase: '"Inter", sans-serif',
+});

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,0 +1,6 @@
+import { addons } from 'storybook/manager-api';
+import altinnTheme from './altinn';
+
+addons.setConfig({
+    theme: altinnTheme,
+});


### PR DESCRIPTION
Before:

<img width="1268" height="492" alt="image" src="https://github.com/user-attachments/assets/f4489071-67d7-4646-adbd-3b886cb9da1c" />

Now:

<img width="1692" height="698" alt="image" src="https://github.com/user-attachments/assets/ab11d224-2afd-486e-8776-63a63082a683" />

Theme can easily be extended brand icon etc.


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
