### PR TITLE
chore: update props to package- and area-li

### DIFF
--- a/lib/components/AccessAreaListItem/AccessAreaListItem.stories.tsx
+++ b/lib/components/AccessAreaListItem/AccessAreaListItem.stories.tsx
@@ -29,7 +29,7 @@ const meta = {
     name: testArea.name,
     titleAs: 'h3',
     iconUrl: testArea.icon,
-    badgeText: '2 of 7',
+    badge: '2 of 7',
     colorTheme: 'company',
     loading: false,
     shadow: 'sm',
@@ -94,7 +94,7 @@ export const AreaWithPackages = (args: AccessAreaListItemProps) => {
         colorTheme="company"
         expanded={expanded}
         onClick={() => setExpanded(!expanded)}
-        badgeText={`2 of ${testArea.packages.length}`}
+        badge={`2 of ${testArea.packages.length}`}
       >
         {children(args.colorTheme)}
       </AccessAreaListItem>
@@ -121,7 +121,7 @@ export const AllAreas = (args: AccessAreaListItemProps) => {
                 size={args.size}
                 expanded={expanded === area.id}
                 onClick={() => setExpanded((prev) => (prev === area.id ? null : area.id))}
-                badgeText={`0 of ${area.packages.length}`}
+                badge={`0 of ${area.packages.length}`}
                 shadow="sm"
               >
                 {area.description && <p>{area.description}</p>}

--- a/lib/components/AccessAreaListItem/AccessAreaListItem.tsx
+++ b/lib/components/AccessAreaListItem/AccessAreaListItem.tsx
@@ -1,12 +1,11 @@
 import type { Color } from '../../types';
-import type { BadgeProps } from '../Badge';
 import type { IconProps, SvgElement } from '../Icon';
 import { ListItem } from '../List';
 import type { ListItemProps } from '../List';
 import styles from './accessAreaListItem.module.css';
 
 interface AccessAreaListItemDefaultProps
-  extends Pick<ListItemProps, 'size' | 'onClick' | 'expanded' | 'loading' | 'shadow' | 'border'> {
+  extends Pick<ListItemProps, 'size' | 'onClick' | 'expanded' | 'loading' | 'shadow' | 'border' | 'badge'> {
   /** Id of the item */
   id: string;
   /** Name of the Access Area */
@@ -15,8 +14,6 @@ interface AccessAreaListItemDefaultProps
   titleAs?: 'p' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'div' | 'span';
   /** Color theme of the Access Area */
   colorTheme?: Color;
-  /** Optional Badge to display things like the number of packages a user has in the area */
-  badgeText?: string;
   /** Children to render when the item is expanded */
   children?: React.ReactNode;
 }
@@ -33,7 +30,7 @@ export const AccessAreaListItem = ({
   children,
   expanded = false,
   onClick,
-  badgeText,
+  badge,
   colorTheme,
   loading,
   titleAs = 'h3',
@@ -46,7 +43,7 @@ export const AccessAreaListItem = ({
     color: colorTheme,
     altText: '',
   } as IconProps;
-  const badge = badgeText ? ({ label: badgeText, color: colorTheme } as BadgeProps) : undefined;
+  
   return (
     <ListItem
       as="button"

--- a/lib/components/AccessPackageListItem/AccessPackageListItem.tsx
+++ b/lib/components/AccessPackageListItem/AccessPackageListItem.tsx
@@ -4,7 +4,7 @@ import { ListItem, type ListItemProps } from '../List';
 export interface AccessPackageListItemProps
   extends Pick<
     ListItemProps,
-    'color' | 'onClick' | 'as' | 'description' | 'size' | 'controls' | 'loading' | 'shadow' | 'border'
+    'color' | 'onClick' | 'as' | 'description' | 'size' | 'controls' | 'loading' | 'shadow' | 'border' | 'badge'
   > {
   id: string;
   name: string;


### PR DESCRIPTION
To accept more "badge-varaints" like avatar-groups and warnings in area and package components the  current "badge-text" props has been replaced by a "badge" prop that accepts either a node or "BadgeProps". 

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
