### PR TITLE
fix: menu should lose its active state on mouse enter leave

### DIFF
--- a/lib/components/Menu/MenuBase.tsx
+++ b/lib/components/Menu/MenuBase.tsx
@@ -24,6 +24,7 @@ export interface MenuListProps {
   children?: ReactNode;
   ref?: React.Ref<HTMLUListElement>;
   onMouseEnter?: MouseEventHandler;
+  onMouseLeave?: MouseEventHandler;
 }
 
 export interface MenuListItemProps {
@@ -34,6 +35,8 @@ export interface MenuListItemProps {
   children?: ReactNode;
   style?: React.CSSProperties;
   dataIndex?: number;
+  onMouseEnter?: MouseEventHandler;
+  onMouseLeave?: MouseEventHandler;
 }
 
 export const MenuBase = ({ as = 'nav', color, theme, className, children }: MenuBaseProps) => {
@@ -45,10 +48,24 @@ export const MenuBase = ({ as = 'nav', color, theme, className, children }: Menu
   );
 };
 
-export const MenuList = ({ as = 'ul', role = 'group', className, children, ref, onMouseEnter }: MenuListProps) => {
+export const MenuList = ({
+  as = 'ul',
+  role = 'group',
+  className,
+  children,
+  ref,
+  onMouseEnter,
+  onMouseLeave,
+}: MenuListProps) => {
   const Component = as;
   return (
-    <Component className={cx(styles.list, className)} role={role} ref={ref} onMouseEnter={onMouseEnter}>
+    <Component
+      className={cx(styles.list, className)}
+      role={role}
+      ref={ref}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
       {children}
     </Component>
   );
@@ -61,10 +78,19 @@ export const MenuListItem = ({
   children,
   style,
   dataIndex,
+  onMouseEnter,
+  onMouseLeave,
 }: MenuListItemProps) => {
   const Component = as;
   return (
-    <Component className={cx(styles.item, className)} role={role} style={style} data-index={dataIndex}>
+    <Component
+      className={cx(styles.item, className)}
+      role={role}
+      style={style}
+      data-index={dataIndex}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
       {children}
     </Component>
   );

--- a/lib/components/Menu/MenuItems.tsx
+++ b/lib/components/Menu/MenuItems.tsx
@@ -51,7 +51,7 @@ export const MenuItems = ({
   onSelect = () => {},
 }: MenuItemsProps) => {
   const ref = useRef<HTMLUListElement>(null);
-  const { menu } = useMenu<MenuItemProps, MenuGroupProps>({
+  const { menu, setActiveIndex } = useMenu<MenuItemProps, MenuGroupProps>({
     items,
     groups,
     groupByKey: 'groupId',
@@ -85,7 +85,7 @@ export const MenuItems = ({
                 const { expanded } = itemProps;
                 const nextItem = group?.items[index + 1];
                 return (
-                  <MenuListItem expanded={expanded} key={index}>
+                  <MenuListItem expanded={expanded} key={index} onMouseLeave={() => setActiveIndex(-1)}>
                     <MenuItem
                       {...itemProps}
                       size={itemProps?.size || groupProps?.defaultItemSize || defaultItemSize}


### PR DESCRIPTION
Fikser global menu-glitch med hover

Før:
<img width="700" height="778" alt="image" src="https://github.com/user-attachments/assets/a8461512-1fa0-44db-9644-be39ed0df4c7" />

Etter:

<img width="672" height="740" alt="image" src="https://github.com/user-attachments/assets/96d54d65-be91-4141-9754-5daa4a74f141" />


## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
