### PR TITLE
fix: header-menu-props

### DIFF
--- a/examples/admin/useAdminLayout.tsx
+++ b/examples/admin/useAdminLayout.tsx
@@ -24,7 +24,7 @@ export const useAdminLayout = ({ accountId = 'diaspora', pageId = 'admin' }): Ad
   };
 
   const layout = useLayout({ color: 'neutral', theme: 'subtle', accountId });
-  const account = layout?.header?.menu?.currentAccount;
+  const account = layout?.header?.globalMenu?.currentAccount;
 
   const menuItems = adminMenuItems.map((item, index) => {
     const storyBookId = storybookPages?.[item.id as keyof typeof storybookPages];

--- a/examples/inbox/useInboxBeta.tsx
+++ b/examples/inbox/useInboxBeta.tsx
@@ -152,10 +152,7 @@ export const useInboxBeta = ({ pageId = 'inbox', q, ...props }: UseInboxProps): 
     },
   };
 
-  const interimHeader = layout?.header;
-
-  const interimGlobalMenu = {
-    ...interimHeader?.menu,
+  const interimMenu = {
     items: [
       {
         ...sidebarItems[0],
@@ -166,8 +163,9 @@ export const useInboxBeta = ({ pageId = 'inbox', q, ...props }: UseInboxProps): 
   };
 
   const betaHeader = {
-    ...interimHeader,
-    menu: interimGlobalMenu,
+    ...layout?.header,
+    desktopMenu: interimMenu,
+    mobileMenu: interimMenu,
   };
 
   const search = useInboxSearch({

--- a/examples/layout/globalMenu.ts
+++ b/examples/layout/globalMenu.ts
@@ -1,36 +1,30 @@
 import {
+  ArchiveIcon,
   BellIcon,
   BookmarkIcon,
   Buildings2Icon,
   ChatExclamationmarkIcon,
+  DocPencilIcon,
+  FileCheckmarkIcon,
   HeartIcon,
   InboxIcon,
   MenuGridIcon,
+  TrashIcon,
 } from '@navikt/aksel-icons';
 import { accountMenu } from '../';
-import type { AccountMenuProps, GlobalMenuProps } from '../../lib';
+import type { AccountMenuProps, GlobalMenuProps, MenuProps } from '../../lib';
 
-export const globalMenu: GlobalMenuProps = {
-  accountMenu: {
-    ...(accountMenu as AccountMenuProps),
-    menuItemsVirtual: {
-      isVirtualized: true,
-      scrollRefStyles: {
-        maxHeight: 'calc(90vh - 8rem)',
-      },
-    },
-  },
-  currentEndUserLabel: 'Logget inn som Mathias Dyngeland',
-  menuLabel: 'Meny',
-  backLabel: 'Tilbake',
-  logoutButton: { label: 'Logg ut' },
-  changeLabel: 'Endre',
+export const desktopMenu: MenuProps = {
+  defaultIconTheme: 'surface',
   groups: {
     apps: {
-      defaultIconTheme: 'surface',
       divider: true,
     },
+    help: {
+      defaultIconTheme: 'transparent',
+    },
     profile: {
+      defaultIconTheme: 'transparent',
       defaultItemColor: 'person',
     },
   },
@@ -104,4 +98,78 @@ export const globalMenu: GlobalMenuProps = {
       title: 'Varslingsinnstillinger',
     },
   ],
+};
+
+const mobileMenuItems = desktopMenu.items?.map((item) => {
+  if (item.id === 'inbox') {
+    return {
+      ...item,
+      expanded: true,
+      items: [
+        {
+          id: 'drafts',
+          groupId: '2',
+          icon: DocPencilIcon,
+          title: 'Utkast',
+          badge: {
+            label: '2',
+          },
+        },
+        {
+          id: 'sent',
+          groupId: '2',
+          icon: FileCheckmarkIcon,
+          title: 'Sendt',
+          badge: {
+            label: '3',
+          },
+        },
+        {
+          id: 'bookmarks',
+          groupId: '3',
+          icon: BookmarkIcon,
+          title: 'Lagrede søk',
+          badge: {
+            label: '5',
+          },
+        },
+        {
+          id: 'archive',
+          groupId: '4',
+          icon: ArchiveIcon,
+          title: 'Arkiv',
+        },
+        {
+          id: 'trash',
+          groupId: '4',
+          icon: TrashIcon,
+          title: 'Papirkurv',
+        },
+      ],
+    };
+  }
+  return item;
+});
+
+export const mobileMenu = {
+  ...desktopMenu,
+  items: mobileMenuItems,
+};
+
+export const globalMenu: GlobalMenuProps = {
+  accountMenu: {
+    ...(accountMenu as AccountMenuProps),
+    menuItemsVirtual: {
+      isVirtualized: true,
+      scrollRefStyles: {
+        maxHeight: 'calc(90vh - 8rem)',
+      },
+    },
+  },
+  menu: desktopMenu,
+  currentEndUserLabel: 'Logget inn som Mathias Dyngeland',
+  menuLabel: 'Meny',
+  backLabel: 'Tilbake',
+  logoutButton: { label: 'Logg ut' },
+  changeLabel: 'Endre',
 };

--- a/examples/layout/header.ts
+++ b/examples/layout/header.ts
@@ -2,7 +2,7 @@ import { globalMenu, localeSwitcher } from '../';
 import type { HeaderProps } from '../../lib';
 
 export const header: HeaderProps = {
-  menu: globalMenu,
+  globalMenu: globalMenu,
   locale: localeSwitcher,
   search: {
     name: 'global-search',

--- a/examples/layout/useGlobalMenu.tsx
+++ b/examples/layout/useGlobalMenu.tsx
@@ -14,7 +14,7 @@ export const useGlobalMenu = ({
   ...props
 }: UseGlobalMenuProps) => {
   if (!accountId) {
-    return { ...loginMenu, menuLabel };
+    return { menu: loginMenu, menuLabel };
   }
 
   const accountMenu = props?.accountMenu || getAccountMenu({ accounts });

--- a/examples/layout/useHeader.ts
+++ b/examples/layout/useHeader.ts
@@ -21,12 +21,12 @@ export const useHeader = ({ accountId, accounts = defaultAccounts, ...args }: Us
 
   /* setup globalMenu */
 
-  const menu = useGlobalMenu({ ...args.menu, accountId, accounts });
+  const globalMenu = useGlobalMenu({ ...args.globalMenu, accountId, accounts });
 
   return {
-    menu,
+    globalMenu,
     locale,
     search,
-    currentAccount: menu?.currentAccount as Account,
+    currentAccount: globalMenu?.currentAccount as Account,
   };
 };

--- a/lib/components/GlobalMenu/GlobalMenu.stories.tsx
+++ b/lib/components/GlobalMenu/GlobalMenu.stories.tsx
@@ -2,8 +2,8 @@ import { InformationSquareIcon, LeaveIcon } from '@navikt/aksel-icons';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import type { Account } from '..';
-import { globalMenu, loginMenu } from '../../../examples';
-import { GlobalMenu, type GlobalMenuProps } from './GlobalMenu';
+import { GlobalMenu, type GlobalMenuProps, type MenuProps } from '../';
+import { globalMenu, loginMenu, mobileMenu } from '../../../examples';
 
 const meta = {
   title: 'Layout/GlobalMenu',
@@ -46,6 +46,20 @@ export const CompanyAccount = (args: GlobalMenuProps) => {
   return <GlobalMenu {...args} currentAccount={currentAccount} onSelectAccount={onSelectAccount} />;
 };
 
+export const MobileMenu = (args: GlobalMenuProps) => {
+  const accounts = args?.accountMenu?.items!;
+  const [currentAccount, setCurrentAccount] = useState<Account>(accounts[1] as Account);
+
+  const onSelectAccount = (id: string) => {
+    const account = accounts?.find((item) => item.id === id);
+    if (account) {
+      setCurrentAccount(account as Account);
+    }
+  };
+
+  return <GlobalMenu {...args} menu={mobileMenu} currentAccount={currentAccount} onSelectAccount={onSelectAccount} />;
+};
+
 export const SingleAccount = (args: GlobalMenuProps) => {
   const accountMenu = args?.accountMenu!;
   const currentAccount = accountMenu?.items[0] as Account;
@@ -62,7 +76,7 @@ export const SingleAccount = (args: GlobalMenuProps) => {
 
 export const Login: Story = {
   args: {
-    ...loginMenu,
+    menu: loginMenu,
     logoutButton: undefined,
   },
 };
@@ -78,7 +92,7 @@ export const InterimMenu = (args: GlobalMenuProps) => {
     }
   };
 
-  const inboxMenuItem = args?.items?.find((item) => item.id === 'inbox');
+  const inboxMenuItem = args?.menu?.items?.find((item) => item.id === 'inbox');
 
   const items = [
     {
@@ -103,7 +117,12 @@ export const InterimMenu = (args: GlobalMenuProps) => {
   return (
     <GlobalMenu
       {...args}
-      items={items as GlobalMenuProps['items']}
+      menu={
+        {
+          ...args?.menu,
+          items: items,
+        } as MenuProps
+      }
       currentAccount={currentAccount}
       onSelectAccount={onSelectAccount}
     />

--- a/lib/components/GlobalMenu/GlobalMenu.tsx
+++ b/lib/components/GlobalMenu/GlobalMenu.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useMemo, useState } from 'react';
 import { type Account, AccountMenu, type AccountMenuProps, CurrentAccount } from '../';
-import { Menu, type MenuItemGroups, type MenuItemProps, MenuListItem } from '../Menu';
+import { Menu, MenuListItem, type MenuProps } from '../Menu';
 import { BackButton } from './BackButton';
 import { EndUserLabel } from './EndUserLabel';
 import { GlobalMenuBase, GlobalMenuFooter, GlobalMenuHeader } from './GlobalMenuBase';
@@ -9,8 +9,7 @@ import { LogoutButton, type LogoutButtonProps } from './LogoutButton';
 
 export interface GlobalMenuProps {
   accountMenu?: AccountMenuProps;
-  items: MenuItemProps[];
-  groups?: MenuItemGroups;
+  menu?: MenuProps;
   menuLabel?: string;
   backLabel?: string;
   logoutButton?: LogoutButtonProps;
@@ -25,8 +24,7 @@ export interface GlobalMenuProps {
 
 export const GlobalMenu = ({
   accountMenu,
-  items = [],
-  groups,
+  menu,
   backLabel = 'Back',
   currentAccount,
   currentEndUserLabel = 'Signed in',
@@ -48,7 +46,7 @@ export const GlobalMenu = ({
   };
 
   const itemsWithToggle = useMemo(() => {
-    return items.map((item) => ({
+    return (menu?.items ?? []).map((item) => ({
       ...item,
       onClick: () => {
         item.onClick?.();
@@ -64,7 +62,7 @@ export const GlobalMenu = ({
           }))
         : undefined,
     }));
-  }, [items, onClose]);
+  }, [menu, onClose]);
 
   if (selectingAccount) {
     return (
@@ -85,14 +83,18 @@ export const GlobalMenu = ({
 
     return (
       <GlobalMenuBase aria-label={ariaLabel} color={currentAccount?.type}>
-        <CurrentAccount
-          account={currentAccount}
-          multipleAccounts={multipleAccounts}
-          as={multipleAccounts ? 'button' : 'div'}
-          onClick={multipleAccounts ? onToggleAccounts : undefined}
-        />
-        <MenuListItem as="div" role="separator" />
-        <Menu groups={groups} items={itemsWithToggle} theme="default" />
+        {currentAccount && (
+          <>
+            <CurrentAccount
+              account={currentAccount}
+              multipleAccounts={multipleAccounts}
+              as={multipleAccounts ? 'button' : 'div'}
+              onClick={multipleAccounts ? onToggleAccounts : undefined}
+            />
+            <MenuListItem as="div" role="separator" />
+          </>
+        )}
+        {menu && <Menu {...menu} items={itemsWithToggle} />}
         {logoutButton && (
           <>
             <MenuListItem as="div" role="separator" />
@@ -108,7 +110,7 @@ export const GlobalMenu = ({
 
   return (
     <GlobalMenuBase aria-label={ariaLabel}>
-      <Menu groups={groups} items={itemsWithToggle} />
+      {menu && <Menu {...menu} items={itemsWithToggle} />}
       {logoutButton && (
         <>
           <MenuListItem as="div" role="separator" />

--- a/lib/components/Header/Header.stories.tsx
+++ b/lib/components/Header/Header.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta } from '@storybook/react-vite';
-import { type Account, type GlobalMenuProps, Header, type HeaderProps } from '../';
-import { header, inboxMenu, useHeader } from '../../../examples';
+import { Header, type HeaderProps } from '../';
+import { header, mobileMenu, useHeader } from '../../../examples';
 
 const meta = {
   title: 'Layout/Header',
@@ -31,26 +31,11 @@ export const CurrentAccount = (args: HeaderProps) => {
 };
 
 export const CompanyAccount = (args: HeaderProps) => {
-  const header = useHeader({ ...args });
-  const currentAccount = header?.menu?.accountMenu?.items[1] as Account;
-  return <Header {...(header as HeaderProps)} currentAccount={currentAccount} />;
+  const header = useHeader({ ...args, accountId: 'company' });
+  return <Header {...(header as HeaderProps)} />;
 };
 
-export const SubmenuExpanded = (args: HeaderProps) => {
-  const header = useHeader({ ...args });
-  const menuItems = [
-    {
-      ...args.menu.items[0],
-      items: inboxMenu.items.slice(1),
-      expanded: true,
-    },
-    ...args.menu.items.slice(1, 3),
-  ];
-
-  const globalMenu = {
-    ...header.menu,
-    items: menuItems,
-  } as GlobalMenuProps;
-
-  return <Header {...header} menu={globalMenu as GlobalMenuProps} />;
+export const MobileMenu = (args: HeaderProps) => {
+  const header = useHeader({ ...args, accountId: 'company' });
+  return <Header {...(header as HeaderProps)} mobileMenu={mobileMenu} />;
 };

--- a/lib/components/Header/Header.tsx
+++ b/lib/components/Header/Header.tsx
@@ -1,4 +1,6 @@
 'use client';
+import { HeaderBase, HeaderGroup, HeaderLogo, type HeaderLogoProps, HeaderSearch, type MenuProps } from '../';
+import { useIsDesktop } from '../../hooks/useIsDesktop.ts';
 import type { BadgeProps } from '../Badge';
 import { DrawerBase, DropdownBase } from '../Dropdown';
 import { GlobalMenu, GlobalMenuButton, type GlobalMenuProps } from '../GlobalMenu';
@@ -6,16 +8,14 @@ import type { Account } from '../GlobalMenu';
 import { useRootContext } from '../RootProvider';
 import { Searchbar, type SearchbarProps } from '../Searchbar';
 import { LocaleSwitcher, type LocaleSwitcherProps } from './';
-import { HeaderBase } from './HeaderBase';
-import { HeaderGroup } from './HeaderGroup';
-import { HeaderLogo, type HeaderLogoProps } from './HeaderLogo';
-import { HeaderSearch } from './HeaderSearch';
-
-import { useIsDesktop } from '../../hooks/useIsDesktop.ts';
 import styles from './header.module.css';
 
 export interface HeaderProps {
-  menu: GlobalMenuProps;
+  globalMenu: GlobalMenuProps;
+  /** Use to override globalMenu.menu on desktop */
+  desktopMenu?: MenuProps;
+  /** Use to override globalMenu.menu on mobile */
+  mobileMenu?: MenuProps;
   locale?: LocaleSwitcherProps;
   search?: SearchbarProps;
   currentAccount?: Account;
@@ -23,7 +23,16 @@ export interface HeaderProps {
   logo?: HeaderLogoProps;
 }
 
-export const Header = ({ menu, locale, search, currentAccount, logo = {}, badge }: HeaderProps) => {
+export const Header = ({
+  globalMenu,
+  desktopMenu,
+  mobileMenu,
+  locale,
+  search,
+  currentAccount,
+  logo = {},
+  badge,
+}: HeaderProps) => {
   const { currentId, toggleId, openId, closeAll } = useRootContext();
 
   const onSearchFocus = () => {
@@ -60,9 +69,9 @@ export const Header = ({ menu, locale, search, currentAccount, logo = {}, badge 
             currentAccount={currentAccount}
             onClick={onToggleMenu}
             expanded={currentId === 'menu'}
-            label={menu?.menuLabel}
+            label={globalMenu?.menuLabel}
           />
-          {menu && (
+          {globalMenu && (
             <DropdownBase
               layout="desktop"
               padding
@@ -70,7 +79,12 @@ export const Header = ({ menu, locale, search, currentAccount, logo = {}, badge 
               open={currentId === 'menu'}
               className={styles.dropdown}
             >
-              <GlobalMenu {...menu} currentAccount={currentAccount} onClose={closeAll} />
+              <GlobalMenu
+                {...globalMenu}
+                menu={desktopMenu || globalMenu?.menu}
+                currentAccount={currentAccount}
+                onClose={closeAll}
+              />
             </DropdownBase>
           )}
         </div>
@@ -80,9 +94,14 @@ export const Header = ({ menu, locale, search, currentAccount, logo = {}, badge 
           <Searchbar {...search} expanded={currentId === 'search'} onClose={onSearchClose} onFocus={onSearchFocus} />
         </HeaderSearch>
       )}
-      {menu && (
+      {globalMenu && (
         <DrawerBase open={currentId === 'menu'} className={styles.drawer}>
-          <GlobalMenu {...menu} currentAccount={currentAccount} onClose={closeAll} />
+          <GlobalMenu
+            {...globalMenu}
+            menu={mobileMenu || globalMenu?.menu}
+            currentAccount={currentAccount}
+            onClose={closeAll}
+          />
         </DrawerBase>
       )}
     </HeaderBase>

--- a/lib/components/Header/index.tsx
+++ b/lib/components/Header/index.tsx
@@ -2,6 +2,8 @@ export * from './Header';
 export * from './HeaderBase';
 export * from './HeaderLogo';
 export * from './HeaderButton';
+export * from './HeaderGroup';
+export * from './HeaderSearch';
 
 export * from './LocaleButton';
 export * from './LocaleSwitcher';

--- a/lib/stories/InboxBeta.stories.tsx
+++ b/lib/stories/InboxBeta.stories.tsx
@@ -193,3 +193,20 @@ export const Information = () => {
     </Layout>
   );
 };
+
+export const InformationStandalone = () => {
+  const { layout } = useInboxBeta({ pageId: "s1" });
+
+  return (
+    <Layout
+      header={layout?.header}
+      footer={layout?.footer}
+      sidebar={{ hidden: true }}
+      color="neutral"
+      theme="default"
+    >
+      <BetaText />
+      <BetaModal open={false} />
+    </Layout>
+  );
+};

--- a/package.json
+++ b/package.json
@@ -2,17 +2,11 @@
   "name": "@altinn/altinn-components",
   "version": "0.38.5",
   "main": "dist/index.js",
-  "files": [
-    "dist/",
-    "!dist/stories/",
-    "!dist/components/*/*.stories.js"
-  ],
+  "files": ["dist/", "!dist/stories/", "!dist/components/*/*.stories.js"],
   "types": "dist/types/lib/index.d.ts",
   "type": "module",
   "description": "Reusable react components",
-  "sideEffects": [
-    "*.css"
-  ],
+  "sideEffects": ["*.css"],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
Replace “items” and “groups”-props with a single “menu”-prop in GlobalMenu. Rename “menu” prop in Header to “globalMenu” and add “desktopMenu” and “mobileMenu” props to Header.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #564

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
