### PR TITLE
fix: not interactive list-item in tab-index with cursor pointer

### DIFF
--- a/lib/components/AccessAreaListItem/AccessAreaListItem.tsx
+++ b/lib/components/AccessAreaListItem/AccessAreaListItem.tsx
@@ -5,7 +5,10 @@ import type { ListItemProps } from '../List';
 import styles from './accessAreaListItem.module.css';
 
 interface AccessAreaListItemDefaultProps
-  extends Pick<ListItemProps, 'size' | 'onClick' | 'expanded' | 'loading' | 'shadow' | 'border' | 'badge' | 'interactive' | 'as'> {
+  extends Pick<
+    ListItemProps,
+    'size' | 'onClick' | 'expanded' | 'loading' | 'shadow' | 'border' | 'badge' | 'interactive' | 'as'
+  > {
   /** Id of the item */
   id: string;
   /** Name of the Access Area */

--- a/lib/components/List/ListItem.stories.tsx
+++ b/lib/components/List/ListItem.stories.tsx
@@ -332,45 +332,6 @@ export const NonInteractive = () => {
   );
 };
 
-// Test story for non-interactive behavior
-export const NonInteractiveTest: Story = {
-  args: {
-    interactive: false,
-    linkIcon: false,
-    title: 'Non-interactive test',
-    icon: { theme: 'surface', svgElement: TeddyBearIcon },
-  },
-  render: (args) => {
-    let clickCount = 0;
-    const handleClick = () => {
-      clickCount += 1; // should not increment for non-interactive
-    };
-    return (
-      <List>
-        <ListItem {...args} description={`Clicks: ${clickCount}`} onClick={handleClick} as="div" />
-      </List>
-    );
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const titleEl = canvas.getByText('Non-interactive test');
-    const header = titleEl.closest('[data-interactive]') as HTMLElement;
-    await expect(header).toBeVisible();
-    await expect(header.getAttribute('data-interactive')).toBe('false');
-
-    const tabbable = header.querySelector('[tabindex]');
-    await expect(tabbable).toBeNull();
-
-    await userEvent.hover(header);
-    const cursor = getComputedStyle(header).cursor;
-    await expect(cursor).not.toBe('pointer');
-
-    await userEvent.click(header);
-    // Description should remain unchanged (still Clicks: 0)
-    await expect(canvas.getByText(/Clicks: 0/)).toBeVisible();
-  },
-};
-
 export const Variants: Story = {
   render: (args) => (
     <List>


### PR DESCRIPTION
List items are always in the tabindex and have the CSS property cursor: pointer even if they are not interactive. 
This PR introduces a fix for this for the UserItem and PackageItem by passing the interactive prop to the ListItem header to ensure the data-interactive prop is set correctly.

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
