### PR TITLE
fix: overflow for gui action button when labels are long

### DIFF
--- a/lib/components/Dialog/dialogAction.module.css
+++ b/lib/components/Dialog/dialogAction.module.css
@@ -1,5 +1,6 @@
 .action {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 0.5rem;
 }


### PR DESCRIPTION

On small screens, fixes this: 

<img width="756" height="388" alt="image" src="https://github.com/user-attachments/assets/af9b1bc6-41f1-4943-839e-14069d404016" />


## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
