### PR TITLE
fix: Reduce gaps and margins in header mobile view

### DIFF
--- a/lib/components/Header/Header.tsx
+++ b/lib/components/Header/Header.tsx
@@ -55,7 +55,7 @@ export const Header = ({
       open={currentId === 'search' || currentId === 'menu' || currentId === 'locale'}
       onClose={closeAll}
     >
-      <HeaderLogo {...logo} badge={badge} className={styles.logo} />
+      <HeaderLogo {...logo} badge={badge} />
       {search && isDesktop && (
         <HeaderSearch expanded={currentId === 'search'}>
           <Searchbar {...search} expanded={currentId === 'search'} onClose={onSearchClose} onFocus={onSearchFocus} />

--- a/lib/components/Header/headerBase.module.css
+++ b/lib/components/Header/headerBase.module.css
@@ -4,8 +4,14 @@
   align-items: center;
   justify-content: space-between;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: 0;
   padding: 1rem;
+}
+
+@media (min-width: 1024px) {
+  .header {
+    gap: 1rem;
+  }
 }
 
 .backdrop {

--- a/lib/components/Header/headerGroup.module.css
+++ b/lib/components/Header/headerGroup.module.css
@@ -2,5 +2,11 @@
   position: relative;
   display: flex;
   align-items: center;
-  column-gap: 1rem;
+  column-gap: 0;
+}
+
+@media (min-width: 1024px) {
+  .group {
+    column-gap: 1rem;
+  }
 }

--- a/lib/components/Header/headerLogo.module.css
+++ b/lib/components/Header/headerLogo.module.css
@@ -8,7 +8,13 @@
 .symbol {
   width: 2rem;
   height: 2rem;
-  margin: 6px;
+  margin: 0;
+}
+
+@media (min-width: 1024px) {
+  .symbol {
+    margin: 6px;
+  }
 }
 
 .riksSymbol {


### PR DESCRIPTION
In this PR (numbers referenced in figure below):

1. Removes margin of 6px for mobile devices
2. Removes gap of 1rem for mobile devices
3. Removes gap of 1rem for mobile devices

The language picker needs its area to be able to hit it on a touch device, so it has not been reduced in size.

<img width="710" height="388" alt="CleanShot 2025-10-16 at 14 07 32@2x" src="https://github.com/user-attachments/assets/feb45e0a-8bc9-4e90-9f85-ec43192d5252" />

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #2955

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
