### PR TITLE
fix: Add row gap in mobile view to header

### DIFF
--- a/lib/components/Header/headerBase.module.css
+++ b/lib/components/Header/headerBase.module.css
@@ -4,7 +4,7 @@
   align-items: center;
   justify-content: space-between;
   flex-wrap: wrap;
-  gap: 0;
+  row-gap: 1rem;
   padding: 1rem;
 }
 


### PR DESCRIPTION
<img width="1204" height="572" alt="CleanShot 2025-10-17 at 09 28 55@2x" src="https://github.com/user-attachments/assets/8d7f0792-052a-4c61-9538-7934ef29951f" />
## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
