### PR TITLE
ci: remove the use of npm token when publishing

### DIFF
--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -39,6 +39,4 @@ jobs:
         - run: pnpm build
           if: ${{ steps.release.outputs.release_created }}
         - run: pnpm publish
-          env:
-            NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Removing the use of npm token as we have transitioned to using Trusted Publishers: https://docs.npmjs.com/trusted-publishers

## Related Issue(s)
- #749 