### PR TITLE
fix(ci): ensure latest npm to allow trusted publishers

### DIFF
--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -1,8 +1,8 @@
 name: CI/CD Main
 on:
-    push:
-      branches:
-        - main
+  push:
+    branches:
+      - main
 
 permissions:
   contents: write
@@ -11,32 +11,40 @@ permissions:
   id-token: write
 
 jobs:
-    deploy-documentation:
-      uses: ./.github/workflows/workflow-deploy-storybook.yml
-    release-please:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v4
-        - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
-          id: release
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # The logic below handles the npm publication:
-        # these if statements ensure that a publication only occurs when
-        # a new release is created:
-        - uses: actions/setup-node@v4
-          with:
-            node-version-file: .node-version
-            registry-url: 'https://registry.npmjs.org'
-          if: ${{ steps.release.outputs.release_created }}
-        - name: Setup PNPM
-          uses: pnpm/action-setup@v2
-          if: ${{ steps.release.outputs.release_created }}
-          with:
-            version: '9.12.3'
-        - run: pnpm install --frozen-lockfile
-          if: ${{ steps.release.outputs.release_created }}
-        - run: pnpm build
-          if: ${{ steps.release.outputs.release_created }}
-        - run: pnpm publish
-          if: ${{ steps.release.outputs.release_created }}
+  deploy-documentation:
+    uses: ./.github/workflows/workflow-deploy-storybook.yml
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
+        id: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # The logic below handles the npm publication:
+      # these if statements ensure that a publication only occurs when
+      # a new release is created:
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          registry-url: "https://registry.npmjs.org"
+        if: ${{ steps.release.outputs.release_created }}
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v2
+        if: ${{ steps.release.outputs.release_created }}
+        with:
+          version: "9.12.3"
+      # Ensure npm 11.5.1 or later for trusted publishing
+      # https://github.com/orgs/community/discussions/173102
+      - name: Install npm@latest
+        run: npm install -g npm@latest
+        if: ${{ steps.release.outputs.release_created }}
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        if: ${{ steps.release.outputs.release_created }}
+      - name: Build
+        run: pnpm build
+        if: ${{ steps.release.outputs.release_created }}
+      - name: Publish
+        run: pnpm publish
+        if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

There is a requirement to have at least `npm` version `11.5.1` to allow Trusted Publishing. https://github.com/orgs/community/discussions/173102

## Related Issue(s)
- #749 