### PR TITLE
feat: Support InboxSearch while global header enabled

### DIFF
--- a/lib/components/InboxSearch/InboxSearch.tsx
+++ b/lib/components/InboxSearch/InboxSearch.tsx
@@ -1,0 +1,32 @@
+import { Backdrop } from '../Dropdown';
+import { useRootContext } from '../RootProvider';
+import { Searchbar, type SearchbarProps } from '../Searchbar';
+
+export interface InboxSearchProps {
+  search: SearchbarProps;
+}
+
+export const InboxSearch = ({ search }: InboxSearchProps) => {
+  const { currentId, toggleId, openId } = useRootContext();
+
+  const onInboxSearchFocus = () => {
+    openId('inboxSearch');
+  };
+
+  const onInboxSearchClose = () => {
+    toggleId('inboxSearch');
+  };
+
+  return (
+    <>
+      {currentId === 'inboxSearch' && <Backdrop onClick={onInboxSearchClose} />}
+      <Searchbar
+        {...search}
+        expanded={currentId === 'inboxSearch'}
+        onClose={onInboxSearchClose}
+        onFocus={onInboxSearchFocus}
+        useGlobalHeader={true}
+      />
+    </>
+  );
+};

--- a/lib/components/InboxSearch/index.ts
+++ b/lib/components/InboxSearch/index.ts
@@ -1,0 +1,1 @@
+export { InboxSearch, type InboxSearchProps } from './InboxSearch';

--- a/lib/components/Layout/Layout.tsx
+++ b/lib/components/Layout/Layout.tsx
@@ -12,6 +12,7 @@ import {
 import { Footer, type FooterProps } from '../Footer';
 import { GlobalHeader, type GlobalHeaderProps } from '../GlobalHeader';
 import { Header, type HeaderProps } from '../Header';
+import { InboxSearch } from '../InboxSearch';
 import { Menu, type MenuProps } from '../Menu';
 import { useRootContext } from '../RootProvider';
 import { SkipLink, type SkipLinkProps } from '../SkipLink';
@@ -49,6 +50,7 @@ export const Layout = ({
   useGlobalHeader = false,
 }: LayoutProps) => {
   const { currentId } = useRootContext();
+  const search = header && 'search' in header ? header.search : undefined;
 
   return (
     <LayoutBase color={color} theme={currentId === 'accountFullscreen' ? 'default' : theme} currentId={currentId}>
@@ -56,12 +58,14 @@ export const Layout = ({
       {header && (useGlobalHeader ? <GlobalHeader {...header} /> : <Header {...header} />)}
       <LayoutBody currentId={currentId}>
         {sidebar && (
-          <LayoutSidebar hidden={sidebar?.hidden} color={sidebar?.color} {...sidebar}>
+          <LayoutSidebar hidden={sidebar?.hidden} color={sidebar?.color} {...sidebar} useGlobalHeader={useGlobalHeader}>
             {sidebar?.menu && <Menu {...sidebar?.menu} />}
             {sidebar?.children}
           </LayoutSidebar>
         )}
+
         <LayoutContent color={content?.color} id="main-content">
+          {useGlobalHeader && search && <InboxSearch search={search} />}
           {children}
         </LayoutContent>
       </LayoutBody>

--- a/lib/components/Layout/LayoutSidebar.tsx
+++ b/lib/components/Layout/LayoutSidebar.tsx
@@ -13,11 +13,24 @@ export interface LayoutSidebarProps {
   hidden?: boolean;
   sticky?: boolean;
   children?: ReactNode;
+  useGlobalHeader?: boolean;
 }
 
-export const LayoutSidebar = ({ color, hidden = false, sticky, children }: LayoutSidebarProps) => {
+export const LayoutSidebar = ({
+  color,
+  hidden = false,
+  sticky,
+  children,
+  useGlobalHeader = false,
+}: LayoutSidebarProps) => {
   return (
-    <aside className={styles.sidebar} data-color={color} data-sticky={sticky} aria-hidden={hidden}>
+    <aside
+      className={styles.sidebar}
+      data-color={color}
+      data-sticky={sticky}
+      data-use-global-header={useGlobalHeader}
+      aria-hidden={hidden}
+    >
       {children}
     </aside>
   );

--- a/lib/components/Layout/layoutSidebar.module.css
+++ b/lib/components/Layout/layoutSidebar.module.css
@@ -15,6 +15,10 @@
     width: 224px;
   }
 
+  .sidebar[data-use-global-header="true"] {
+    margin-top: 4.125rem;
+  }
+
   .sidebar[data-sticky="true"] {
     position: sticky;
     top: 0;

--- a/lib/components/Searchbar/Searchbar.tsx
+++ b/lib/components/Searchbar/Searchbar.tsx
@@ -14,6 +14,7 @@ export interface SearchbarProps extends SearchbarFieldProps {
   autocomplete?: AutocompleteProps;
   expanded?: boolean;
   tabIndex?: number;
+  useGlobalHeader?: boolean;
 }
 
 export const Searchbar = ({
@@ -22,6 +23,7 @@ export const Searchbar = ({
   expanded = false,
   onClose,
   tabIndex,
+  useGlobalHeader = false,
   ...search
 }: SearchbarProps) => {
   const [inputHasFocus, setInputFocus] = useState<boolean>(false);
@@ -60,6 +62,7 @@ export const Searchbar = ({
       expanded={expanded}
       autocomplete={!!autocomplete}
       onBlurCapture={onBlurCapture}
+      useGlobalHeader={useGlobalHeader}
     >
       <SearchbarField
         {...search}

--- a/lib/components/Searchbar/SearchbarBase.tsx
+++ b/lib/components/Searchbar/SearchbarBase.tsx
@@ -8,6 +8,7 @@ export interface SearchbarBaseProps {
   expanded?: boolean;
   autocomplete?: boolean;
   onBlurCapture?: React.FocusEventHandler<HTMLDivElement>;
+  useGlobalHeader?: boolean;
 }
 
 export const SearchbarBase = ({
@@ -16,8 +17,14 @@ export const SearchbarBase = ({
   expanded = false,
   onBlurCapture,
   autocomplete = false,
+  useGlobalHeader = false,
 }: SearchbarBaseProps) => {
-  const searchBaseStyles = cx(styles.searchbar, className, expanded && styles.searchbarExpanded);
+  const searchBaseStyles = cx(
+    styles.searchbar,
+    className,
+    expanded && styles.searchbarExpanded,
+    useGlobalHeader && styles.searchbarLocal,
+  );
   return (
     <div className={searchBaseStyles} data-autocomplete={autocomplete} onBlurCapture={onBlurCapture}>
       {children}

--- a/lib/components/Searchbar/searchbarBase.module.css
+++ b/lib/components/Searchbar/searchbarBase.module.css
@@ -18,3 +18,20 @@
   border-top-right-radius: 0;
   margin-top: -2px;
 }
+
+.searchbarLocal {
+  width: 100%;
+  padding: var(--dsc-spacing-4) 0;
+  z-index: 100;
+}
+
+@media (min-width: 1024px) {
+  .searchbarLocal {
+    max-width: 320px;
+    margin-right: auto;
+  }
+
+  .searchbarLocal.searchbarExpanded {
+    max-width: 640px;
+  }
+}

--- a/lib/stories/Inbox.stories.tsx
+++ b/lib/stories/Inbox.stories.tsx
@@ -222,6 +222,19 @@ export const InboxEmptyPage = () => {
   );
 };
 
+export const InboxWithGlobalSearch = () => {
+  const { layout, toolbar } = useInbox({});
+
+  return (
+    <Layout {...layout} useGlobalHeader={true}>
+      <PageBase margin="page">
+        <Toolbar {...toolbar} />
+        <EmptySection />
+      </PageBase>
+    </Layout>
+  );
+};
+
 export const SearchPage = () => {
   let params = new URL(document.location.toString()).searchParams;
   let q = params.get("q") || "regnskap";

--- a/package.json
+++ b/package.json
@@ -2,17 +2,11 @@
   "name": "@altinn/altinn-components",
   "version": "0.45.4",
   "main": "dist/index.js",
-  "files": [
-    "dist/",
-    "!dist/stories/",
-    "!dist/components/*/*.stories.js"
-  ],
+  "files": ["dist/", "!dist/stories/", "!dist/components/*/*.stories.js"],
   "types": "dist/types/lib/index.d.ts",
   "type": "module",
   "description": "Reusable react components",
-  "sideEffects": [
-    "*.css"
-  ],
+  "sideEffects": ["*.css"],
   "scripts": {
     "test": "vitest run",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Render "local" InboxSearch when GlobalHeader is enabled. 

## Related Issue(s)
https://github.com/Altinn/dialogporten-frontend/issues/3106

Related to epic: https://github.com/Altinn/dialogporten-frontend/issues/3020

https://www.figma.com/design/qI3fyaeV3WS8QhCcLBQhyR/Arbeidsflate-Sandbox?node-id=3162-52707&t=oUu5SDnWp0UfTlg9-0

<img width="1624" height="1006" alt="Screenshot 2025-11-06 at 12 48 48" src="https://github.com/user-attachments/assets/6e4ff477-fbb5-4fa1-9deb-cd1e83999e0a" />

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
