### PR TITLE
fix: Mobile view searchbar overlapping fix

### DIFF
--- a/lib/components/Searchbar/searchbarBase.module.css
+++ b/lib/components/Searchbar/searchbarBase.module.css
@@ -22,14 +22,18 @@
 .searchbarLocal {
   width: 100%;
   padding: var(--dsc-spacing-4) 0;
-  z-index: 100;
   margin-bottom: 16px;
+}
+
+.searchbarLocal.searchbarExpanded {
+  z-index: 100;
 }
 
 @media (min-width: 1024px) {
   .searchbarLocal {
     max-width: 320px;
     margin-right: auto;
+    z-index: 100;
   }
 
   .searchbarLocal.searchbarExpanded {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
https://github.com/Altinn/dialogporten-frontend/issues/3166

<img width="702" height="438" alt="Screenshot 2025-11-12 at 16 30 05" src="https://github.com/user-attachments/assets/77cfe160-38bd-4c7e-9953-f0cd412dfb9d" />
<img width="710" height="413" alt="Screenshot 2025-11-12 at 16 30 13" src="https://github.com/user-attachments/assets/3adc789b-9f08-4b38-8109-4db39a7c0e86" />


## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
