### PR TITLE
fix: add support for maxItemsCountReachedLabel to support a scalable label for avatar groups with many items

### DIFF
--- a/lib/components/Avatar/AvatarGroup.stories.tsx
+++ b/lib/components/Avatar/AvatarGroup.stories.tsx
@@ -67,6 +67,16 @@ export const CompanyAndPerson: Story = {
   },
 };
 
+export const CustomLabel = (args: AvatarGroupProps) => {
+  const items = new Array(5000).fill(null).map((_, index) => ({ name: index + 'AA' }));
+
+  return (
+    <Flex direction="col" align="start" spacing={2}>
+      <AvatarGroup {...args} items={items} maxItemsCountReachedLabel="+" defaultType="company" size="sm" />
+    </Flex>
+  );
+};
+
 export const MaxItemsCount = (args: AvatarGroupProps) => {
   const items = [{ name: 'A' }, { name: 'B' }, { name: 'C' }, { name: 'D' }];
 

--- a/lib/components/Avatar/AvatarGroup.tsx
+++ b/lib/components/Avatar/AvatarGroup.tsx
@@ -21,6 +21,8 @@ export interface AvatarGroupProps {
   className?: string;
   /** Custom styles. */
   style?: CSSProperties;
+  /** Custom Label for items counts reached **/
+  maxItemsCountReachedLabel?: string;
 }
 
 export const isAvatarGroupProps = (icon: unknown): icon is AvatarGroupProps => {
@@ -37,6 +39,7 @@ export const AvatarGroup = ({
   size,
   className,
   style,
+  maxItemsCountReachedLabel,
 }: AvatarGroupProps) => {
   const maxItems = useMemo(() => items.slice(0, maxItemsCount).reverse(), [items, maxItemsCount]);
 
@@ -48,7 +51,10 @@ export const AvatarGroup = ({
     <ul className={cx(styles.group, className)} data-size={size} data-count={maxItems?.length} style={style}>
       {maxItems.map((avatar, index) => {
         const lastLegalAvatarReached = index === maxItemsCount - 1;
-        const customLabel = avatar.customLabel || lastLegalAvatarReached ? items.length.toString() : undefined;
+        const customLabel =
+          avatar.customLabel || lastLegalAvatarReached
+            ? maxItemsCountReachedLabel || items.length.toString()
+            : undefined;
         return (
           <li className={cx(styles.item)} key={index}>
             <Avatar


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
