### PR TITLE
fix(accountSelector): deduplicate favorite parties in filtered search results

### DIFF
--- a/examples/layout/useGlobalHeader.tsx
+++ b/examples/layout/useGlobalHeader.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { localeSwitcher as localExample, useGlobalHeaderMenu, useLocale } from '../';
 import { getAuthorizedPartiesData } from '../';
-import type { GlobalHeaderProps } from '../../lib/components/GlobalHeader';
-import { useAccountSelector } from '../../lib/hooks';
+import type { GlobalHeaderProps } from '../../lib';
+import { useAccountSelector } from '../../lib';
 
 export const useGlobalHeader = ({
   state = 'loggedIn',

--- a/lib/components/Account/AccountMenu.tsx
+++ b/lib/components/Account/AccountMenu.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { type CSSProperties, useEffect, useState } from 'react';
+import { type CSSProperties, useEffect, useMemo, useState } from 'react';
 import { Menu, type MenuItemProps, type MenuProps, type MenuSearchProps } from '../';
 
 export interface AccountSearchProps extends MenuSearchProps {
@@ -64,18 +64,25 @@ export const AccountMenu = ({
 
   const applicableFilterAccount = filterAccount || defaultFilterAccount;
 
-  const filteredAccountMenu = filterString
-    ? accountMenu
-        .filter((item) => applicableFilterAccount(item, filterString))
-        .map((item) => {
-          return {
-            ...item,
-            groupId: 'search',
-            title: item?.title || item.name,
-            highlightWords: [filterString],
-          };
-        })
-    : accountMenu;
+  const filteredAccountMenu = useMemo(() => {
+    if (!filterString) return accountMenu;
+
+    return Array.from(
+      new Map(
+        accountMenu
+          .filter((item) => applicableFilterAccount(item, filterString))
+          .map((item) => [
+            item.id,
+            {
+              ...item,
+              groupId: 'search',
+              title: item?.title || item.name,
+              highlightWords: [filterString],
+            },
+          ]),
+      ).values(),
+    );
+  }, [accountMenu, filterString, applicableFilterAccount]);
 
   const filterAccountGroups = filterString
     ? {

--- a/lib/components/Avatar/AvatarGroup.stories.tsx
+++ b/lib/components/Avatar/AvatarGroup.stories.tsx
@@ -72,7 +72,7 @@ export const CustomLabel = (args: AvatarGroupProps) => {
 
   return (
     <Flex direction="col" align="start" spacing={2}>
-      <AvatarGroup {...args} items={items} maxItemsCountReachedLabel="+" defaultType="company" size="sm" />
+      <AvatarGroup {...args} items={items} maxItemsCountReachedLabel="..." defaultType="company" size="sm" />
     </Flex>
   );
 };

--- a/lib/components/Layout/Layout.stories.tsx
+++ b/lib/components/Layout/Layout.stories.tsx
@@ -13,7 +13,7 @@ import {
   useGlobalMenu,
   useLayout,
 } from '../../../examples';
-import { useAccountSelector } from '../../hooks/useAccountSelector';
+import { useAccountSelector } from '../../hooks';
 import type { AccountSelectorProps } from '../GlobalHeader/AccountSelector';
 
 // Add custom story args interface for easier testing

--- a/lib/components/Layout/Layout.tsx
+++ b/lib/components/Layout/Layout.tsx
@@ -63,7 +63,6 @@ export const Layout = ({
             {sidebar?.children}
           </LayoutSidebar>
         )}
-
         <LayoutContent color={content?.color} id="main-content">
           {useGlobalHeader && search && <InboxSearch search={search} />}
           {children}

--- a/lib/hooks/useAccountSelector.tsx
+++ b/lib/hooks/useAccountSelector.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { type AccountMenuItemProps, IconButton, type MenuGroupProps } from '../components';
 import type { AccountSelectorProps } from '../components/GlobalHeader/AccountSelector';
 import { formatDisplayName } from '../functions';
-import { formatDate } from '../functions/date';
+import { formatDate } from '../functions';
 import { useIsDesktop } from './useIsDesktop';
 
 /** The DTO for the authorized party endpoint */
@@ -137,6 +137,7 @@ export const useAccountSelector = ({
     );
 
     const organizationAccountItems: AccountMenuItemProps[] = [];
+
     for (const org of organizations) {
       const orgAccountItem = getAccountFromAuthorizedParty(
         languageCode!,
@@ -249,6 +250,7 @@ export const useAccountSelector = ({
  * @param currentAccountUuid - UUID of currently selected account for selection state
  * @param isFavorite - Whether this account is marked as favorite
  * @param toggleFavorite - Callback for toggling favorite status
+ * @param isDesktopScreen - Whether this is intended for a desktop screen
  * @param parent - Parent organization (for subunits)
  * @param isSelf - Whether this is the user's own account
  * @returns Formatted account menu item with all necessary props


### PR DESCRIPTION
Parties that appear twice in the search results because they are marked as favorites should be deduplicated when filtering (i.e., when searchValue.length > 0).

This matches the expected behavior in the account search in the toolbar.


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)

https://github.com/Altinn/altinn-components/issues/815

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
