### PR TITLE
fix: global menu on does not inherit color and overrides with company

### DIFF
--- a/lib/components/Dropdown/DrawerBase.tsx
+++ b/lib/components/Dropdown/DrawerBase.tsx
@@ -27,7 +27,6 @@ export const DrawerBase = ({
       className={cx(styles.drawer, className)}
       data-placement={placement}
       data-variant="default"
-      data-color="company"
       data-expanded={open}
       data-layout={dataLayout}
     >

--- a/lib/components/Layout/Layout.stories.tsx
+++ b/lib/components/Layout/Layout.stories.tsx
@@ -276,3 +276,28 @@ export const Fullscreen = (args: LayoutStoryArgs) => {
     </RootProvider>
   );
 };
+
+export const Profile = (args: LayoutStoryArgs) => {
+  const layout = useLayout(args);
+  const accountMenu = useAccountMenu({ accountId: 'diaspora' });
+  const globalMenu = useGlobalMenu({ accountId: 'diaspora' });
+  const accountSelector: AccountSelectorProps = {
+    accountMenu: accountMenu,
+  };
+  return (
+    <RootProvider>
+      <Layout
+        {...args}
+        {...layout}
+        header={{
+          ...layout.header,
+          accountSelector: accountSelector,
+          globalMenu: globalMenu,
+        }}
+        color="person"
+      >
+        {args.children}
+      </Layout>
+    </RootProvider>
+  );
+};


### PR DESCRIPTION
This PR fixes issue that company color (blue) overrides instead of inherit parent color.

This shows a person themed layout, on mobile, however, the drawer gets company color instead:


<img width="996" height="1244" alt="image" src="https://github.com/user-attachments/assets/2956071f-5908-4fa4-9945-bc500192ad2f" />

@LeifHelstad observed this here: https://github.com/Altinn/dialogporten-frontend/issues/3204




## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
