### PR TITLE
fix(accountSelector): Could not close selector on mobile

### DIFF
--- a/lib/components/GlobalHeader/AccountSelector.tsx
+++ b/lib/components/GlobalHeader/AccountSelector.tsx
@@ -1,6 +1,7 @@
 import { CaretDownCircleIcon, CaretUpCircleIcon } from '@navikt/aksel-icons';
 import cx from 'classnames';
 import { useEffect, useState } from 'react';
+import { useIsDesktop } from '../../hooks/useIsDesktop';
 import { AccountMenu, type AccountMenuProps } from '../Account';
 import { Button } from '../Button';
 import { DsHeading, DsSpinner } from '../DsComponents';
@@ -20,6 +21,7 @@ export interface AccountSelectorProps {
 
 export const AccountSelector = ({ accountMenu, forceOpenFullScreen, className, loading }: AccountSelectorProps) => {
   const { currentId, openId, closeAll, languageCode } = useRootContext();
+  const isDesktop = useIsDesktop();
   const isFullScreen = currentId === 'accountFullscreen';
   const [searchString, setSearchString] = useState('');
   const [forceOpenFullScreenState, setForceOpenFullScreenState] = useState<boolean | undefined>(forceOpenFullScreen);
@@ -35,8 +37,10 @@ export const AccountSelector = ({ accountMenu, forceOpenFullScreen, className, l
   useEffect(() => {
     if (forceOpenFullScreenState === true && !isFullScreen) {
       openId('accountFullscreen');
+    } else if (!isDesktop && currentId === 'account') {
+      openId('accountFullscreen');
     }
-  }, [forceOpenFullScreenState, isFullScreen, openId]);
+  }, [forceOpenFullScreenState, isFullScreen, isDesktop, currentId, openId]);
 
   const { minimize, fullscreen, searchText, heading } = getTexts(languageCode);
 
@@ -90,7 +94,7 @@ export const AccountSelector = ({ accountMenu, forceOpenFullScreen, className, l
           scrollRefStyles={!isFullScreen && accountMenu.isVirtualized ? { maxHeight: 'calc(40vh)' } : undefined}
         />
       </div>
-      {forceOpenFullScreenState !== true && (
+      {forceOpenFullScreenState !== true && isDesktop && (
         <Button
           icon={
             isFullScreen ? (

--- a/lib/components/GlobalHeader/GlobalHeader.tsx
+++ b/lib/components/GlobalHeader/GlobalHeader.tsx
@@ -75,11 +75,23 @@ export const GlobalHeader = ({
             onClick={accountSelector.accountMenu?.currentAccount ? onToggleAccountMenu : onLoginClick}
             expanded={accountSelectionOpen}
             loading={accountSelector.loading}
+            disabled={accountSelector.forceOpenFullScreen}
           />
         )}
-        {globalSearch && <GlobalSearchButton onClick={ToggleSearch} expanded={currentId === 'search'} />}
+        {globalSearch && (
+          <GlobalSearchButton
+            onClick={ToggleSearch}
+            expanded={currentId === 'search'}
+            disabled={accountSelector?.forceOpenFullScreen}
+          />
+        )}
         <div className={styles.relative}>
-          <GlobalMenuButton onClick={onToggleMenu} expanded={currentId === 'menu'} label={globalMenu?.menuLabel} />
+          <GlobalMenuButton
+            onClick={onToggleMenu}
+            expanded={currentId === 'menu'}
+            disabled={accountSelector?.forceOpenFullScreen}
+            label={globalMenu?.menuLabel}
+          />
           {globalMenu && (
             <DropdownBase
               layout="desktop"
@@ -117,10 +129,7 @@ export const GlobalHeader = ({
           className={cx(styles.drawer)}
           dataLayout={isDesktop ? 'desktop' : 'mobile'}
         >
-          <AccountSelector
-            {...accountSelector}
-            forceOpenFullScreen={accountSelector.forceOpenFullScreen || !isDesktop ? accountSelectionOpen : undefined}
-          />
+          <AccountSelector {...accountSelector} forceOpenFullScreen={accountSelector.forceOpenFullScreen} />
         </DrawerBase>
       )}
       {globalSearch && (

--- a/lib/components/GlobalHeader/GlobalSearchButton.tsx
+++ b/lib/components/GlobalHeader/GlobalSearchButton.tsx
@@ -1,21 +1,21 @@
 'use client';
 import { MagnifyingGlassIcon, XMarkIcon } from '@navikt/aksel-icons';
-import { DsButton, useRootContext } from '../';
+import { DsButton, type DsButtonProps, useRootContext } from '../';
 import { useIsDesktop } from '../../hooks/useIsDesktop';
 import styles from './globalSearch.module.css';
 
-export const GlobalSearchButton = ({
-  onClick,
-  expanded,
-}: {
+export interface GlobalSearchButtonProps extends DsButtonProps {
   onClick: () => void;
   expanded: boolean;
-}) => {
+}
+
+export const GlobalSearchButton = ({ onClick, expanded, ...buttonProps }: GlobalSearchButtonProps) => {
   const { languageCode } = useRootContext();
   const { search, close } = getTexts(languageCode);
   const isDesktop = useIsDesktop();
   return (
     <DsButton
+      {...buttonProps}
       type="button"
       icon={!isDesktop}
       title={expanded ? close : search}

--- a/package.json
+++ b/package.json
@@ -2,17 +2,11 @@
   "name": "@altinn/altinn-components",
   "version": "0.48.0",
   "main": "dist/index.js",
-  "files": [
-    "dist/",
-    "!dist/stories/",
-    "!dist/components/*/*.stories.js"
-  ],
+  "files": ["dist/", "!dist/stories/", "!dist/components/*/*.stories.js"],
   "types": "dist/types/lib/index.d.ts",
   "type": "module",
   "description": "Reusable react components",
-  "sideEffects": [
-    "*.css"
-  ],
+  "sideEffects": ["*.css"],
   "scripts": {
     "test": "vitest run",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<img width="478" height="930" alt="image" src="https://github.com/user-attachments/assets/0864eff9-ef82-41e5-8ce3-8afa6a8e9380" />


## Description
There was an undiscovered bug that caused one to not be able to close the accountSelector when on mobile.
This has now been fixed by not using the forceOpen prop to display the modal view

In addition to this, the search and menu buttons have now been disabled whenever forceOpen is set on the accountSelector.
This will prevent glitchy behavior and keep focus on the task of selecting an account when this is forced.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
