### PR TITLE
feat: Add footer sidebar section, update GlobalMenu Ref, add sidebar story

### DIFF
--- a/examples/layout/globalMenuDesignReference.tsx
+++ b/examples/layout/globalMenuDesignReference.tsx
@@ -10,7 +10,6 @@ import {
 } from '@navikt/aksel-icons';
 import { accountMenu } from '../';
 import type { AccountMenuProps, GlobalMenuProps_old, MenuProps } from '../../lib';
-import { Badge } from '../../lib';
 
 const designReferenceMenuItems: MenuProps['items'] = [
   {
@@ -18,23 +17,17 @@ const designReferenceMenuItems: MenuProps['items'] = [
     groupId: 'apps',
     size: 'lg',
     icon: InboxFillIcon,
-    title: (
-      <>
-        Innboks <Badge label="Beta" />
-      </>
-    ),
+    title: 'Innboks',
     selected: true,
+    badge: { label: 'Beta', color: 'neutral', variant: 'base' },
   },
   {
     id: 'access-control',
     groupId: 'apps',
     size: 'lg',
     icon: PadlockLockedFillIcon,
-    title: (
-      <>
-        Tilgangsstyring <Badge label="Beta" />
-      </>
-    ),
+    title: 'Tilgangsstyring',
+    badge: { label: 'Beta', color: 'neutral', variant: 'base' },
   },
   {
     id: 'forms',

--- a/lib/components/Layout/Layout.stories.tsx
+++ b/lib/components/Layout/Layout.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta } from '@storybook/react-vite';
 import { useState } from 'react';
-import { Flex, RootProvider } from '..';
+import { Badge, Flex, RootProvider } from '..';
 import type { LayoutProps } from '../';
 import { Layout, List, type ListItemProps, PageBase } from '../';
 import {
@@ -295,6 +295,34 @@ export const Profile = (args: LayoutStoryArgs) => {
           globalMenu: globalMenu,
         }}
         color="person"
+      >
+        {args.children}
+      </Layout>
+    </RootProvider>
+  );
+};
+
+export const SidebarReference = (args: LayoutStoryArgs) => {
+  const layout = useLayout(args);
+  const accountMenu = useAccountMenu({ accountId: 'diaspora' });
+  const globalMenu = useGlobalMenu({ accountId: 'diaspora' });
+  const accountSelector: AccountSelectorProps = {
+    accountMenu: accountMenu,
+  };
+  return (
+    <RootProvider>
+      <Layout
+        {...args}
+        {...layout}
+        header={{
+          ...layout.header,
+          accountSelector: accountSelector,
+          globalMenu: globalMenu,
+        }}
+        sidebar={{
+          ...args.sidebar,
+          footer: <Badge label="Beta" variant="base" color="neutral" size="sm" />,
+        }}
       >
         {args.children}
       </Layout>

--- a/lib/components/Layout/Layout.tsx
+++ b/lib/components/Layout/Layout.tsx
@@ -58,7 +58,12 @@ export const Layout = ({
       {header && (useGlobalHeader ? <GlobalHeader {...header} /> : <Header {...header} />)}
       <LayoutBody currentId={currentId}>
         {sidebar && (
-          <LayoutSidebar hidden={sidebar?.hidden} color={sidebar?.color} {...sidebar} useGlobalHeader={useGlobalHeader}>
+          <LayoutSidebar
+            hidden={sidebar?.hidden}
+            color={sidebar?.color}
+            footer={sidebar?.footer}
+            useGlobalHeader={useGlobalHeader}
+          >
             {sidebar?.menu && <Menu {...sidebar?.menu} />}
             {sidebar?.children}
           </LayoutSidebar>

--- a/lib/components/Layout/LayoutSidebar.tsx
+++ b/lib/components/Layout/LayoutSidebar.tsx
@@ -13,6 +13,7 @@ export interface LayoutSidebarProps {
   hidden?: boolean;
   sticky?: boolean;
   children?: ReactNode;
+  footer?: ReactNode;
   useGlobalHeader?: boolean;
 }
 
@@ -21,6 +22,7 @@ export const LayoutSidebar = ({
   hidden = false,
   sticky,
   children,
+  footer,
   useGlobalHeader = false,
 }: LayoutSidebarProps) => {
   return (
@@ -32,6 +34,7 @@ export const LayoutSidebar = ({
       aria-hidden={hidden}
     >
       {children}
+      {footer && <div className={styles.footer}>{footer}</div>}
     </aside>
   );
 };

--- a/lib/components/Layout/layoutSidebar.module.css
+++ b/lib/components/Layout/layoutSidebar.module.css
@@ -6,6 +6,13 @@
   display: none;
 }
 
+.footer {
+  margin-top: 0.75rem;
+  padding-top: 1rem;
+  padding-left: 0.5rem;
+  border-top: 1px solid var(--ds-color-border-subtle);
+}
+
 @media (min-width: 1024px) {
   .sidebar {
     align-self: flex-start;

--- a/lib/hooks/useAccountSelector.tsx
+++ b/lib/hooks/useAccountSelector.tsx
@@ -117,9 +117,7 @@ export const useAccountSelector = ({
       .filter((party) => isPersonType(party.type) && party.partyUuid !== selfAccountUuid)
       .sort(compareFn);
 
-    const organizations = [...partyListDTO]
-      .filter((party) => isOrgType(party.type))
-      .sort(compareFn)
+    const organizations = [...partyListDTO].filter((party) => isOrgType(party.type)).sort(compareFn);
 
     // Build account items of self, people and organizations
     const selfAccountItem = getAccountFromAuthorizedParty(

--- a/package.json
+++ b/package.json
@@ -2,17 +2,11 @@
   "name": "@altinn/altinn-components",
   "version": "0.49.0",
   "main": "dist/index.js",
-  "files": [
-    "dist/",
-    "!dist/stories/",
-    "!dist/components/*/*.stories.js"
-  ],
+  "files": ["dist/", "!dist/stories/", "!dist/components/*/*.stories.js"],
   "types": "dist/types/lib/index.d.ts",
   "type": "module",
   "description": "Reusable react components",
-  "sideEffects": [
-    "*.css"
-  ],
+  "sideEffects": ["*.css"],
   "scripts": {
     "test": "vitest run",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
Updated GlobalMenu design reference story with new beta badge design. 

Added new footer section to Layout -> Sidebar. 
Example of use: 
`  
const layoutProps: LayoutProps = {
    (...)
    sidebar: {
     (...)
      footer: <Badge label={t('word.beta')} variant="base" color="neutral" size="sm" />,
    },
};`


Added sidebar reference story "Sidebar Reference"

## ---
<img width="986" height="709" alt="Screenshot 2025-11-26 at 15 47 21" src="https://github.com/user-attachments/assets/2af2f3e9-202d-4815-a5a9-98fa5dfaa790" />


## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
