### PR TITLE
fix(AccountSelector): Do not use parent name to control the color of account avatars

### DIFF
--- a/lib/hooks/useAccountSelector.tsx
+++ b/lib/hooks/useAccountSelector.tsx
@@ -314,7 +314,6 @@ const getAccountFromAuthorizedParty = (
       type: type,
       isParent: !parent,
       isDeleted: party?.isDeleted,
-      colorKey: parentName ?? undefined,
     },
     name: name,
     description: description,

--- a/package.json
+++ b/package.json
@@ -2,17 +2,11 @@
   "name": "@altinn/altinn-components",
   "version": "0.50.0",
   "main": "dist/index.js",
-  "files": [
-    "dist/",
-    "!dist/stories/",
-    "!dist/components/*/*.stories.js"
-  ],
+  "files": ["dist/", "!dist/stories/", "!dist/components/*/*.stories.js"],
   "types": "dist/types/lib/index.d.ts",
   "type": "module",
   "description": "Reusable react components",
-  "sideEffects": [
-    "*.css"
-  ],
+  "sideEffects": ["*.css"],
   "scripts": {
     "test": "vitest run",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We do not always have the name of a subunits parent. Thus, using a subunits parents name as the color key for the avatar color is removed from the useAccountSelector so that we avoid conflicting colors for the same party, like in this example:

<img width="1134" height="358" alt="image" src="https://github.com/user-attachments/assets/2a3118a3-9d04-4f1a-a06c-662d0c01ef56" />


## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
