### PR TITLE
fix(UserListItem): Text-overflow to ellipsis on description

### DIFF
--- a/lib/components/UserListItem/UserListItem.stories.tsx
+++ b/lib/components/UserListItem/UserListItem.stories.tsx
@@ -1,106 +1,106 @@
-import { EyeIcon, TrashIcon } from "@navikt/aksel-icons";
-import type { Meta } from "@storybook/react-vite";
-import { useState } from "react";
-import { ContextMenu } from "../ContextMenu";
-import { List } from "../List";
-import { UserListItem, type UserListItemProps } from "./UserListItem";
+import { EyeIcon, TrashIcon } from '@navikt/aksel-icons';
+import type { Meta } from '@storybook/react-vite';
+import { useState } from 'react';
+import { ContextMenu } from '../ContextMenu';
+import { List } from '../List';
+import { UserListItem, type UserListItemProps } from './UserListItem';
 
 const meta = {
-  title: "Access/UserListItem",
+  title: 'Access/UserListItem',
   component: UserListItem,
-  tags: ["autodocs", "beta"],
+  tags: ['autodocs', 'beta'],
   parameters: {},
   args: {
-    id: "user-1",
-    size: "md",
+    id: 'user-1',
+    size: 'md',
     loading: false,
-    name: "Julie Josefine Beritsen",
-    description: "født 01.02.1993",
-    type: "person",
-    roleNames: ["Styrets leder"],
-    shadow: "sm",
+    name: 'Julie Josefine Beritsen',
+    description: 'født 01.02.1993',
+    type: 'person',
+    roleNames: ['Styrets leder'],
+    shadow: 'sm',
     linkIcon: false,
     collapsible: false,
-    as: "div",
+    as: 'div',
     interactive: true,
     subUnit: false,
-    titleAs: "h3",
-    border: "none",
-    color: "company",
+    titleAs: 'h3',
+    border: 'none',
+    color: 'company',
     expanded: false,
     children: <p>Custom content</p>,
   },
   argTypes: {
     size: {
-      options: ["xs", "sm", "md", "lg", "xl"],
+      options: ['xs', 'sm', 'md', 'lg', 'xl'],
       control: {
-        type: "inline-radio",
+        type: 'inline-radio',
       },
     },
     shadow: {
-      options: ["none", "xs", "sm", "md", "lg"],
+      options: ['none', 'xs', 'sm', 'md', 'lg'],
       control: {
-        type: "inline-radio",
+        type: 'inline-radio',
       },
     },
     type: {
-      options: ["person", "company", "system"],
+      options: ['person', 'company', 'system'],
       control: {
-        type: "inline-radio",
+        type: 'inline-radio',
       },
     },
     as: {
-      options: ["div", "button", "a", "span"],
+      options: ['div', 'button', 'a', 'span'],
       control: {
-        type: "select",
+        type: 'select',
       },
     },
     titleAs: {
-      options: ["h1", "h2", "h3", "h4", "h5", "h6", "p", "div", "span"],
+      options: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'div', 'span'],
       control: {
-        type: "select",
+        type: 'select',
       },
     },
     border: {
-      options: ["none", "solid", "dotted"],
+      options: ['none', 'solid', 'dotted'],
       control: {
-        type: "inline-radio",
+        type: 'inline-radio',
       },
     },
     color: {
-      options: ["inherit", "accent", "company", "person", "neutral"],
+      options: ['inherit', 'accent', 'company', 'person', 'neutral'],
       control: {
-        type: "select",
+        type: 'select',
       },
     },
     loading: {
       control: {
-        type: "boolean",
+        type: 'boolean',
       },
     },
     interactive: {
       control: {
-        type: "boolean",
+        type: 'boolean',
       },
     },
     linkIcon: {
       control: {
-        type: "boolean",
+        type: 'boolean',
       },
     },
     collapsible: {
       control: {
-        type: "boolean",
+        type: 'boolean',
       },
     },
     expanded: {
       control: {
-        type: "boolean",
+        type: 'boolean',
       },
     },
     subUnit: {
       control: {
-        type: "boolean",
+        type: 'boolean',
       },
     },
     // Disable complex controls
@@ -129,15 +129,11 @@ export const MultipleRoles = (args: UserListItemProps) => {
         name="Narvesen AS"
         type="company"
         description="Org.nr.: 123456789"
-        roleNames={[
-          "Regnskapsfører",
-          "Klientadministrator",
-          "Hovedadministrator",
-        ]}
+        roleNames={['Regnskapsfører', 'Klientadministrator', 'Hovedadministrator']}
         interactive={true}
         linkIcon={true}
         onClick={() => alert(`You clicked the link - yay!`)}
-        as={"a"}
+        as={'a'}
       />
     </List>
   );
@@ -152,21 +148,21 @@ export const WithSubUnits = (args: UserListItemProps) => {
         name="Narvesen AS"
         type="company"
         description={undefined}
-        roleNames={["Regnskapsfører"]}
+        roleNames={['Regnskapsfører']}
         expanded={isOpen}
         collapsible={true}
         onClick={() => setIsOpen(!isOpen)}
-        as={"button"}
+        as={'button'}
       >
-        <div style={{ padding: "0.5rem 0 0.5rem 1rem" }}>
-          <List spacing={"sm"}>
+        <div style={{ padding: '0.5rem 0 0.5rem 1rem' }}>
+          <List spacing={'sm'}>
             <UserListItem
               id="subunit1"
               name="Narvesen AS"
               type="company"
               size="xs"
               description="Org.nr. 987654321"
-              roleNames={["Regnskapsfører"]}
+              roleNames={['Regnskapsfører']}
               interactive={false}
               shadow="none"
             />
@@ -204,20 +200,20 @@ export const WithInheritingParties = (args: UserListItemProps) => {
       <UserListItem
         {...args}
         name="Byggebedriftens mestere NO"
-        roleNames={["Regnskapsfører"]}
+        roleNames={['Regnskapsfører']}
         type="company"
         description={undefined}
         expanded={isOpen}
         collapsible={true}
         onClick={() => setIsOpen(!isOpen)}
-        as={"button"}
+        as={'button'}
       >
-        <div style={{ padding: "0.5rem 0 0.5rem 1rem" }}>
-          <List spacing={"sm"}>
+        <div style={{ padding: '0.5rem 0 0.5rem 1rem' }}>
+          <List spacing={'sm'}>
             <UserListItem
               id="subunit1"
               name="Byggebedriftens mestere NO"
-              roleNames={["Regnskapsfører"]}
+              roleNames={['Regnskapsfører']}
               type="company"
               size="xs"
               description="Org.nr. 987654321"
@@ -305,10 +301,10 @@ export const DifferentHeadingLevelsAndSizes = (args: UserListItemProps) => {
 export const WithControls = (args: UserListItemProps) => {
   const menu = (menuId: string) => (
     <ContextMenu
-      id={"menu" + menuId}
+      id={'menu' + menuId}
       items={[
-        { id: "settings" + menuId, title: "See accesses", icon: EyeIcon },
-        { id: "delete" + menuId, title: "Delete user", icon: TrashIcon },
+        { id: 'settings' + menuId, title: 'See accesses', icon: EyeIcon },
+        { id: 'delete' + menuId, title: 'Delete user', icon: TrashIcon },
       ]}
     />
   );
@@ -317,31 +313,31 @@ export const WithControls = (args: UserListItemProps) => {
       <UserListItem
         {...args}
         name="Ådne Makrussen"
-        roleNames={["Styrets leder"]}
-        controls={menu("1")}
+        roleNames={['Styrets leder']}
+        controls={menu('1')}
         linkIcon={true}
         onClick={() => alert(`You clicked the link - yay!`)}
-        as={"button"}
+        as={'button'}
       />
       <UserListItem
         {...args}
         name="Jack Ripper"
         roleNames={undefined}
-        controls={menu("2")}
+        controls={menu('2')}
         linkIcon={true}
         onClick={() => alert(`You clicked the link - yay!`)}
-        as={"button"}
+        as={'button'}
       />
       <UserListItem
         {...args}
         name="Bankmarked AS"
         type="company"
         description="Org.nr.: 987654321"
-        roleNames={["Regnskapsfører"]}
-        controls={menu("3")}
+        roleNames={['Regnskapsfører']}
+        controls={menu('3')}
         linkIcon={true}
         onClick={() => alert(`You clicked the link - yay!`)}
-        as={"button"}
+        as={'button'}
       />
     </List>
   );

--- a/lib/components/UserListItem/UserListItem.tsx
+++ b/lib/components/UserListItem/UserListItem.tsx
@@ -1,43 +1,43 @@
-import { TokenIcon } from "@navikt/aksel-icons";
-import type { AvatarGroupProps, AvatarProps } from "../Avatar";
-import { Badge } from "../Badge";
-import type { IconProps, SvgElement } from "../Icon";
-import { ListItem, ListItemLabel } from "../List";
-import type { ListItemProps } from "../List";
+import { TokenIcon } from '@navikt/aksel-icons';
+import type { AvatarGroupProps, AvatarProps } from '../Avatar';
+import { Badge } from '../Badge';
+import type { IconProps, SvgElement } from '../Icon';
+import { ListItem, ListItemLabel } from '../List';
+import type { ListItemProps } from '../List';
 
-import styles from "./userListItem.module.css";
+import styles from './userListItem.module.css';
 
 export interface UserListItemProps
   extends Pick<
     ListItemProps,
-    | "size"
-    | "controls"
-    | "onClick"
-    | "loading"
-    | "shadow"
-    | "border"
-    | "color"
-    | "linkIcon"
-    | "expanded"
-    | "collapsible"
-    | "children"
-    | "as"
-    | "interactive"
-    | "id"
-    | "className"
+    | 'size'
+    | 'controls'
+    | 'onClick'
+    | 'loading'
+    | 'shadow'
+    | 'border'
+    | 'color'
+    | 'linkIcon'
+    | 'expanded'
+    | 'collapsible'
+    | 'children'
+    | 'as'
+    | 'interactive'
+    | 'id'
+    | 'className'
   > {
   /** Unique identifier for the user item */
   id: string;
   /** Name of the user */
   name: string;
   /** Type of user */
-  type: "person" | "company" | "system";
+  type: 'person' | 'company' | 'system';
   /** Description details for the user */
   description?: string;
   /** Roles of the user to be displayed */
   roleNames?: string[];
   /** The explicit heading or tag of the title, if diverting from the default heading */
-  titleAs?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p" | "div" | "span";
+  titleAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'div' | 'span';
   /** Display as subUnit */
   subUnit?: boolean;
 }
@@ -47,7 +47,7 @@ export const UserListItem = ({
   type,
   description,
   roleNames,
-  titleAs = "h3",
+  titleAs = 'h3',
   subUnit = false,
   loading = false,
   ...props
@@ -55,17 +55,17 @@ export const UserListItem = ({
   let icon: IconProps | SvgElement | AvatarProps | AvatarGroupProps;
 
   switch (type) {
-    case "person":
-      icon = { name: name, type: "person" };
+    case 'person':
+      icon = { name: name, type: 'person' };
       break;
-    case "company":
-      icon = { name: name, type: "company", isParent: !subUnit };
+    case 'company':
+      icon = { name: name, type: 'company', isParent: !subUnit };
       break;
-    case "system":
+    case 'system':
       icon = TokenIcon;
       break;
     default:
-      icon = { name: name, type: "person" };
+      icon = { name: name, type: 'person' };
   }
 
   const badges =
@@ -91,14 +91,5 @@ export const UserListItem = ({
     </div>
   );
 
-  return (
-    <ListItem
-      icon={icon}
-      ariaLabel={name}
-      label={label}
-      description={description}
-      loading={loading}
-      {...props}
-    />
-  );
+  return <ListItem icon={icon} ariaLabel={name} label={label} description={description} loading={loading} {...props} />;
 };

--- a/package.json
+++ b/package.json
@@ -2,17 +2,11 @@
   "name": "@altinn/altinn-components",
   "version": "0.50.2",
   "main": "dist/index.js",
-  "files": [
-    "dist/",
-    "!dist/stories/",
-    "!dist/components/*/*.stories.js"
-  ],
+  "files": ["dist/", "!dist/stories/", "!dist/components/*/*.stories.js"],
   "types": "dist/types/lib/index.d.ts",
   "type": "module",
   "description": "Reusable react components",
-  "sideEffects": [
-    "*.css"
-  ],
+  "sideEffects": ["*.css"],
   "scripts": {
     "test": "vitest run",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<img width="553" height="681" alt="image" src="https://github.com/user-attachments/assets/6d170037-05e0-45d5-ac4d-e3fffff7ab0b" />


## Description
<!--- Describe your changes in detail -->
For UserListItems with long descriptions, we want them to overflow as ellipsis on small screens.
An example for such a use case has been added

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
