### PR TITLE
fix(AccountSelector): Do not remove current user from account list when filtering

### DIFF
--- a/lib/components/GlobalHeader/AccountSelector.tsx
+++ b/lib/components/GlobalHeader/AccountSelector.tsx
@@ -116,18 +116,18 @@ export const AccountSelector = ({
         />
       </div>
       {forceOpenFullScreenState !== true && isDesktop && (
-        <Button
-          icon={
-            isFullScreen ? (
+        <Button variant="ghost" onClick={toggleExpansion}>
+          {isFullScreen ? (
+            <>
               <CaretUpCircleIcon className={styles.btnIcon} aria-hidden="true" />
-            ) : (
+              {minimize}
+            </>
+          ) : (
+            <>
               <CaretDownCircleIcon className={styles.btnIcon} aria-hidden="true" />
-            )
-          }
-          variant="ghost"
-          onClick={toggleExpansion}
-        >
-          {isFullScreen ? minimize : fullscreen}
+              {fullscreen}
+            </>
+          )}
         </Button>
       )}
     </div>

--- a/lib/hooks/useAccountSelector.tsx
+++ b/lib/hooks/useAccountSelector.tsx
@@ -107,7 +107,7 @@ export const useAccountSelector = ({
       return favoriteAccountUuids?.includes(partyUuid);
     };
     const isVisible = (party: AuthorizedParty) => {
-      return !party.isDeleted || showDeletedUnits !== false;
+      return !party.isDeleted || showDeletedUnits !== false || party.partyUuid === currentAccountUuid;
     };
 
     const texts = getTexts(languageCode);

--- a/package.json
+++ b/package.json
@@ -2,17 +2,11 @@
   "name": "@altinn/altinn-components",
   "version": "0.54.0",
   "main": "dist/index.js",
-  "files": [
-    "dist/",
-    "!dist/stories/",
-    "!dist/components/*/*.stories.js"
-  ],
+  "files": ["dist/", "!dist/stories/", "!dist/components/*/*.stories.js"],
   "types": "dist/types/lib/index.d.ts",
   "type": "module",
   "description": "Reusable react components",
-  "sideEffects": [
-    "*.css"
-  ],
+  "sideEffects": ["*.css"],
   "scripts": {
     "test": "vitest run",
     "test:unit": "vitest run --project=unit",


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Found a bug where, if you chose to represent a deleted account and then chose to hide all deleted accounts, the current account was also hidden. This has now been fixed.

Also, fixed the maximize/minimize button to follow new button api

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
