### PR TITLE
fix: Hiding favorite icon for preselected party

### DIFF
--- a/lib/components/Account/AccountListItem.tsx
+++ b/lib/components/Account/AccountListItem.tsx
@@ -17,6 +17,7 @@ export interface AccountListItemProps extends ListItemProps, AccountListItemCont
   isCurrentEndUser?: boolean; // Indicates if this account is the current end user
   isDeleted?: boolean; // Indicates that the account has been deleted
   isParent?: boolean; // Indicates that the account is a parent account
+  isPreselectedParty?: boolean; // Hides favorite icon for preselected party
   contextMenu?: ContextMenuProps;
   label?: string;
 }
@@ -37,6 +38,7 @@ export const AccountListItem = ({
   favouriteLabel,
   onToggleFavourite,
   contextMenu,
+  isPreselectedParty,
   children,
   interactive,
   disabled,
@@ -63,6 +65,7 @@ export const AccountListItem = ({
             favourite={favourite}
             favouriteLabel={favouriteLabel}
             badge={badge}
+            isPreselectedParty={isPreselectedParty}
             isCurrentEndUser={isCurrentEndUser}
             isDeleted={isDeleted}
             onToggleFavourite={onToggleFavourite}

--- a/lib/components/Account/AccountListItemControls.tsx
+++ b/lib/components/Account/AccountListItemControls.tsx
@@ -10,6 +10,7 @@ export interface AccountListItemControlsProps {
   isCurrentEndUser?: boolean; // Optional, used to indicate if this account is the current end user
   isDeleted?: boolean;
   favourite?: boolean; // Optional, used for marking favourite accounts
+  isPreselectedParty?: boolean;
   favouriteLabel?: string; // Optional, label for the favourite icon
   onToggleFavourite?: (id: string) => void; // Optional, callback for toggling favourite status
   accountLabel?: string; // Optional, used for displaying a badge
@@ -24,6 +25,7 @@ export const AccountListItemControls = ({
   badge,
   isCurrentEndUser = false,
   favourite = false,
+  isPreselectedParty = false,
   favouriteLabel,
   onToggleFavourite,
   contextMenu,
@@ -43,7 +45,7 @@ export const AccountListItemControls = ({
   return (
     <ListItemControls>
       {badge && renderBadge()}
-      {!isCurrentEndUser && type !== 'group' && (
+      {!isCurrentEndUser && !isPreselectedParty && type !== 'group' && (
         <Button
           size="xs"
           variant="ghost"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adding option to hide favorite button for preselected party.

<img width="1610" height="616" alt="CleanShot 2026-02-09 at 11 57 07@2x" src="https://github.com/user-attachments/assets/e521520f-a92e-46b7-a528-89670f2fb7ad" />


## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
