### PR TITLE
fix: Virtual account details interferes with global menu

### DIFF
--- a/lib/components/Account/accountListVirtual.module.css
+++ b/lib/components/Account/accountListVirtual.module.css
@@ -10,6 +10,7 @@
   list-style-type: none;
   padding: 0;
   margin: 0;
+  isolation: isolate;
 }
 
 .virtualListItem {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
https://github.com/Altinn/dialogporten-frontend/issues/3746

fix: 
<img width="1624" height="1008" alt="Screenshot 2026-02-18 at 12 21 59" src="https://github.com/user-attachments/assets/83176c52-cd3c-4915-994f-4a8a33c03cfc" />

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
