### PR TITLE
fix: UserListItem roleNames (badges) should break to new lines on narrow screens

### DIFF
--- a/lib/components/UserListItem/userListItem.module.css
+++ b/lib/components/UserListItem/userListItem.module.css
@@ -5,22 +5,22 @@
   flex-wrap: wrap;
   justify-content: start;
   margin-bottom: auto;
+  flex: 1;
   margin-top: calc(var(--dsc-item-my) * 0.85);
 }
 
 .label {
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   align-items: center;
   gap: 0.5rem;
   min-width: 0;
-  flex: 1;
   overflow: hidden;
 }
 
 .label > span {
   min-width: 0;
-  flex: 1;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Description
- UserListItem roleNames (badges) should break to new lines on narrow screens. The label should not be shrunk to 0 width

Before:
https://github.com/user-attachments/assets/659496e0-9d92-4e91-ab16-6ba6529313f9

After:
https://github.com/user-attachments/assets/9c191dc9-8cac-4fc3-9d7a-8f67d2f8d951

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/2214

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
