### PR TITLE
fix: normalize search for subunit organization nr in account selector

### DIFF
--- a/lib/hooks/useAccountSelector.tsx
+++ b/lib/hooks/useAccountSelector.tsx
@@ -345,7 +345,7 @@ const getAccountFromAuthorizedParty = (
     },
     name: name,
     description: description,
-    searchWords: formatType === 'company' ? [name, party?.organizationNumber ?? ''] : [name, party?.dateOfBirth ?? ''],
+    searchWords: formatType === 'person' ? [name, party?.dateOfBirth ?? ''] : [name, party?.organizationNumber ?? ''],
     groupId: group,
     type: formatType,
     selected: currentAccountUuid === party?.partyUuid,


### PR DESCRIPTION
## Description
- Handle subunit in account menu `searchWords`, so it is possible to search for subunit organization number with organization number without spaces

## Related Issue(s)
- continuation of https://github.com/Altinn/altinn-components/issues/924

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
