### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -16,7 +16,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
         id: release
         env:
@@ -24,13 +24,13 @@ jobs:
       # The logic below handles the npm publication:
       # these if statements ensure that a publication only occurs when
       # a new release is created:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .node-version
           registry-url: "https://registry.npmjs.org"
         if: ${{ steps.release.outputs.release_created }}
       - name: Setup PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
         if: ${{ steps.release.outputs.release_created }}
         with:
           version: "9.12.3"

--- a/.github/workflows/ci-cd-pull-request.yml
+++ b/.github/workflows/ci-cd-pull-request.yml
@@ -11,15 +11,15 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .node-version
           
       - name: Setup PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
         with:
           version: '9.12.3'
           

--- a/.github/workflows/storybook-tests.yml
+++ b/.github/workflows/storybook-tests.yml
@@ -5,12 +5,12 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.node-version'
       - name: Setup PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
       - run: pnpm install --frozen-lockfile
       - name: Install Playwright
         run: pnpm exec playwright install

--- a/.github/workflows/workflow-deploy-storybook.yml
+++ b/.github/workflows/workflow-deploy-storybook.yml
@@ -21,18 +21,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.node-version'
       - name: Setup PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
       - run: pnpm install --frozen-lockfile
       - run: pnpm build-storybook
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: "./storybook-static"
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
## Summary

- Pin all third-party GitHub Actions to full commit SHAs instead of mutable version tags
- This is a supply chain hardening measure — prevents tag-swapping attacks where a compromised action tag could point to malicious code
- No functional changes; all actions resolve to the same versions previously used

## Related issue
- https://github.com/Altinn/dialogporten/issues/3697

## Pinned actions

| Action | Version | SHA |
|--------|---------|-----|
| `actions/checkout` | v4.3.1 | `34e11487` |
| `actions/setup-node` | v4.4.0 | `49933ea5` |
| `actions/deploy-pages` | v4.0.5 | `d6db9016` |
| `actions/upload-pages-artifact` | v3.0.1 | `56afc609` |
| `pnpm/action-setup` | v2.4.1 | `eae0cfeb` |

## Affected workflows

- `ci-cd-main.yml`
- `ci-cd-pull-request.yml`
- `storybook-tests.yml`
- `workflow-deploy-storybook.yml`

## Test plan

- [ ] Verify CI passes on this PR (no functional change, same action versions)
- [ ] Confirm all workflow steps still resolve and run correctly