### PR TITLE
feat: add Storybook PR preview deployments

### DIFF
--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -7,8 +7,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  pages: write
-  id-token: write
 
 jobs:
   deploy-documentation:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,46 @@
+name: PR Preview
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup Node.js
+        if: github.event.action != 'closed'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .node-version
+
+      - name: Setup PNPM
+        if: github.event.action != 'closed'
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
+        with:
+          version: '9.12.3'
+
+      - name: Install dependencies
+        if: github.event.action != 'closed'
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Storybook
+        if: github.event.action != 'closed'
+        run: pnpm build-storybook
+
+      - name: Deploy PR preview
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
+        with:
+          source-dir: ./storybook-static

--- a/.github/workflows/workflow-deploy-storybook.yml
+++ b/.github/workflows/workflow-deploy-storybook.yml
@@ -5,9 +5,7 @@ on:
   workflow_call:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: "pages"
@@ -15,9 +13,6 @@ concurrency:
 
 jobs:
   deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -27,12 +22,12 @@ jobs:
           node-version-file: '.node-version'
       - name: Setup PNPM
         uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
+        with:
+          version: '9.12.3'
       - run: pnpm install --frozen-lockfile
       - run: pnpm build-storybook
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
-        with:
-          path: "./storybook-static"
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
+        with:
+          folder: ./storybook-static
+          clean-exclude: pr-preview


### PR DESCRIPTION
## Summary

- Add new `pr-preview.yml` workflow that deploys a Storybook preview for each PR using `rossjrw/pr-preview-action`, with automatic cleanup on PR close
- Migrate main Storybook deployment from the Actions Pages API (`upload-pages-artifact` + `deploy-pages`) to `JamesIves/github-pages-deploy-action` pushing to a `gh-pages` branch, preserving PR preview directories with `clean-exclude`
- Remove unused `pages: write` and `id-token: write` permissions from `ci-cd-main.yml`

## Post-merge manual step

Change GitHub Pages source in repo Settings → Pages from "GitHub Actions" to "Deploy from a branch" (`gh-pages` / `/`).

## Test plan

- [ ] PR preview workflow triggers on this PR
- [ ] `gh-pages` branch is created with preview under `pr-preview/pr-<number>/`
- [ ] PR comment appears with the correct preview URL
- [ ] Push another commit and verify comment is updated (not duplicated)
- [ ] After Pages source is switched, verify preview URL loads
- [ ] Close PR and verify cleanup removes the preview directory
- [ ] Push to main and verify main Storybook deploys without deleting `pr-preview/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)