### PR TITLE
fix: truncate long breadcrumb labels on mobile screens

### DIFF
--- a/lib/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/lib/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -29,3 +29,21 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {},
 };
+
+export const LongLabels: Story = {
+  args: {
+    items: [
+      {
+        label: 'Start',
+        href: '#start',
+      },
+      {
+        label: 'Innboks',
+        href: '#innboks',
+      },
+      {
+        label: 'veldig-lang-tittel-som--man-faktisk-kan-se-eksempler-på-i-produksjon',
+      },
+    ],
+  },
+};

--- a/lib/components/Breadcrumbs/BreadcrumbsLink.module.css
+++ b/lib/components/Breadcrumbs/BreadcrumbsLink.module.css
@@ -43,3 +43,11 @@ button.link:hover {
 .link[aria-current="page"] {
   text-decoration: none;
 }
+
+@media (max-width: 639px) {
+  .link {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 320px;
+  }
+}

--- a/lib/components/Breadcrumbs/breadcrumbs.module.css
+++ b/lib/components/Breadcrumbs/breadcrumbs.module.css
@@ -1,7 +1,6 @@
 .list {
   list-style: none;
   padding: 0;
-  margin: 0;
   margin: 0.625rem 0;
   text-indent: 0;
   display: flex;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
https://github.com/Altinn/altinn-components/issues/1075

## Deploy 🚀

- [x] Deploy Storybook preview
