### PR TITLE
Fix(toolbar): Remove 100% width

### DIFF
--- a/lib/components/Toolbar/toolbar.module.css
+++ b/lib/components/Toolbar/toolbar.module.css
@@ -1,5 +1,4 @@
 .toolbar {
-  width: 100%;
   display: flex;
   flex-wrap: wrap;
   justify-content: start;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

Remove width: 100% from toolbar (which was added last week) to make it more usable with diverse UIs

## Deploy 🚀

- [ ] Deploy Storybook preview
