### PR TITLE
Fix(AccessPackageListItem): Forward variant field for better external color control

### DIFF
--- a/lib/components/AccessPackageListItem/AccessPackageListItem.stories.tsx
+++ b/lib/components/AccessPackageListItem/AccessPackageListItem.stories.tsx
@@ -20,6 +20,7 @@ const meta = {
     border: 'none',
     as: 'button',
     titleAs: 'h3',
+    variant: 'tinted',
   },
   argTypes: {
     size: {
@@ -54,6 +55,12 @@ const meta = {
     },
     titleAs: {
       options: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'div', 'span'],
+      control: {
+        type: 'select',
+      },
+    },
+    variant: {
+      options: ['default', 'tinted', 'light'],
       control: {
         type: 'select',
       },

--- a/lib/components/AccessPackageListItem/AccessPackageListItem.tsx
+++ b/lib/components/AccessPackageListItem/AccessPackageListItem.tsx
@@ -15,6 +15,7 @@ export interface AccessPackageListItemProps
     | 'border'
     | 'badge'
     | 'interactive'
+    | 'variant'
   > {
   id: string;
   name: string;
@@ -27,6 +28,7 @@ export const AccessPackageListItem = ({
   color = 'neutral',
   titleAs = 'h4',
   size = 'sm',
+  variant = 'tinted',
   ...props
 }: AccessPackageListItemProps) => {
   return (
@@ -37,7 +39,7 @@ export const AccessPackageListItem = ({
       ariaLabel={name}
       color={color}
       size={size}
-      variant="tinted"
+      variant={variant}
       {...props}
     />
   );


### PR DESCRIPTION

<img width="1534" height="1008" alt="image" src="https://github.com/user-attachments/assets/4af4e4f2-0769-49e3-a1dd-578ee48c756a" />


<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

Allows for the use of white access packages


## Deploy 🚀

- [ ] Deploy Storybook preview
