### PR TITLE
fix: remove invalid aria-expanded from login button

### DIFF
--- a/lib/components/GlobalHeader/GlobalAccountButton.tsx
+++ b/lib/components/GlobalHeader/GlobalAccountButton.tsx
@@ -93,7 +93,6 @@ export const GlobalAccountButton = ({
       color="company"
       aria-label={texts.login}
       className={cx(styles.loginButton, className)}
-      aria-expanded={expanded}
     >
       {!minimized && <span className={styles.label}>{texts.login}</span>}
       <EnterIcon className={styles.icon} aria-hidden />


### PR DESCRIPTION
The login button in GlobalAccountButton is an action button, not a disclosure control, so aria-expanded is not a valid ARIA attribute for it.

<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
https://github.com/Altinn/altinn-components/issues/1143

## Deploy 🚀

- [ ] Deploy Storybook preview
