### PR TITLE
fix: preventDefault when closing dropdown with ESC key

### DIFF
--- a/lib/components/Dropdown/Dropdown.tsx
+++ b/lib/components/Dropdown/Dropdown.tsx
@@ -180,7 +180,11 @@ export const Dropdown = ({
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+      if (e.key === 'Escape') {
+        e.preventDefault();
+
+        onClose();
+      }
     };
 
     const handleClickOutside = (event: MouseEvent) => {

--- a/lib/components/Toolbar/Toolbar.stories.tsx
+++ b/lib/components/Toolbar/Toolbar.stories.tsx
@@ -255,9 +255,7 @@ export const StaticFilters = () => {
 };
 
 export const StaticFiltersInDialog = () => {
-  const staticFilters = useInboxFilter({
-    filters: inboxFilters
-  });
+  const staticFilters = useInboxFilter({ filters: inboxFilters });
   return (
     <DsDialog.TriggerContext>
       <DsDialog.Trigger>Open Dialog</DsDialog.Trigger>

--- a/lib/components/Toolbar/Toolbar.stories.tsx
+++ b/lib/components/Toolbar/Toolbar.stories.tsx
@@ -1,7 +1,7 @@
 import { BookmarkIcon, XMarkIcon } from '@navikt/aksel-icons';
 import type { Meta } from '@storybook/react-vite';
 import { useEffect, useState } from 'react';
-import { Button, QueryLabel } from '..';
+import { Button, DsDialog, QueryLabel } from '..';
 import { Switch } from '../Forms';
 import { Toolbar, ToolbarFilter, type ToolbarFilterProps, ToolbarMenu, type ToolbarMenuProps, ToolbarSearch } from './';
 import { inboxFilters } from './example.data';
@@ -252,6 +252,20 @@ export const SearchAndSwitch = () => {
 export const StaticFilters = () => {
   const staticFilters = useInboxFilter({ filters: inboxFilters?.map((item) => ({ ...item })) });
   return <Toolbar filter={staticFilters} />;
+};
+
+export const StaticFiltersInDialog = () => {
+  const staticFilters = useInboxFilter({
+    filters: inboxFilters
+  });
+  return (
+    <DsDialog.TriggerContext>
+      <DsDialog.Trigger>Open Dialog</DsDialog.Trigger>
+      <DsDialog style={{ height: '20rem' }}>
+        <Toolbar filter={staticFilters} />
+      </DsDialog>
+    </DsDialog.TriggerContext>
+  );
 };
 
 export const RemovableFilters = () => {


### PR DESCRIPTION
## Description
- Call `preventDefault` when closing dropdown with ESC key. This fixes an issue where clicing ESC when a filter toolbar dropdown menu is open in a dialog closes both the dropdown and the dialog.

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/3119

## Deploy 🚀

- [ ] Deploy Storybook preview
