### PR TITLE
fix: add tabIndex: '-1' to main-content element to focus it after using skip-link

### DIFF
--- a/lib/components/Layout/LayoutContent.tsx
+++ b/lib/components/Layout/LayoutContent.tsx
@@ -15,7 +15,7 @@ interface LayoutContentProps {
  */
 export const LayoutContent = ({ color, children, id = 'main-content' }: LayoutContentProps) => {
   return (
-    <main className={styles.content} data-color={color} id={id}>
+    <main className={styles.content} data-color={color} id={id} tabIndex={-1}>
       {children}
     </main>
   );


### PR DESCRIPTION
## Description
- Add `tabIndex: "-1"` to \<main\> element to focus it correctly after using skip-link. (this is the same as NAV does)

## Related Issue(s)
- https://github.com/Altinn/altinn-components/issues/1161

## Deploy 🚀

- [ ] Deploy Storybook preview
