### PR TITLE
fix: Add prop containerAs on UserListItem

### DIFF
--- a/lib/components/UserListItem/UserListItem.stories.tsx
+++ b/lib/components/UserListItem/UserListItem.stories.tsx
@@ -22,6 +22,7 @@ const meta = {
     linkIcon: false,
     collapsible: false,
     as: 'div',
+    containerAs: 'li',
     interactive: true,
     subUnit: false,
     deleted: false,
@@ -52,6 +53,12 @@ const meta = {
     },
     as: {
       options: ['div', 'button', 'a', 'span'],
+      control: {
+        type: 'select',
+      },
+    },
+    containerAs: {
+      options: ['li', 'div'],
       control: {
         type: 'select',
       },

--- a/lib/components/UserListItem/UserListItem.tsx
+++ b/lib/components/UserListItem/UserListItem.tsx
@@ -22,6 +22,7 @@ export interface UserListItemProps
     | 'interactive'
     | 'id'
     | 'className'
+    | 'containerAs'
   > {
   /** Unique identifier for the user item */
   id: string;


### PR DESCRIPTION
## Description
- Add prop containerAs on `UserListItem`, which will be prop-drilled down to child `ListItem`

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/3217

## Deploy 🚀

- [ ] Deploy Storybook preview
