### PR TITLE
fix(SearchField): restore collapsible behavior with <ds-field> custom…

### DIFF
--- a/lib/components/Forms/SearchField.tsx
+++ b/lib/components/Forms/SearchField.tsx
@@ -116,7 +116,7 @@ export const SearchField = ({
       label={hideLabel ? undefined : label}
       htmlFor={inputId}
       className={cx(styles.field, className)}
-      data-collapsible={collapsible}
+      data-collapsible={collapsible ? true : undefined}
       onBlurCapture={handleBlurCapture}
     >
       <span className={styles.hiddenInput} aria-hidden="true">
@@ -130,7 +130,7 @@ export const SearchField = ({
         type="search"
         value={value}
         className={styles.input}
-        data-collapsible={collapsible}
+        data-collapsible={collapsible ? true : undefined}
         autoCapitalize="off"
         autoComplete="off"
         minLength={minLength}

--- a/lib/components/Forms/searchField.module.css
+++ b/lib/components/Forms/searchField.module.css
@@ -21,7 +21,7 @@
   justify-items: start;
 }
 
-.field[data-collapsible="true"] {
+.field[data-collapsible] {
   width: auto;
 }
 
@@ -30,8 +30,8 @@
   min-width: 25ch;
 }
 
-.field[data-collapsible="true"] .input,
-.field[data-collapsible="true"] .hiddenInput {
+.field[data-collapsible] .input,
+.field[data-collapsible] .hiddenInput {
   min-width: 12.5ch;
   max-width: 25ch;
 }
@@ -55,7 +55,7 @@
   padding-right: 2.25em;
 }
 
-.input[data-collapsible="true"]:placeholder-shown {
+.input[data-collapsible]:placeholder-shown {
   padding-right: 0;
 }
 
@@ -104,16 +104,16 @@
 
 /** Collapsible search field */
 
-.input[data-collapsible="true"] {
+.input[data-collapsible] {
   transition: width 0.5s ease-in-out;
 }
 
-.input[data-collapsible="true"]:placeholder-shown {
+.input[data-collapsible]:placeholder-shown {
   background-color: transparent;
 }
 
-.input[data-collapsible="true"]:focus,
-.input[data-collapsible="true"]:not(:placeholder-shown) {
+.input[data-collapsible]:focus,
+.input[data-collapsible]:not(:placeholder-shown) {
   background-color: var(--ds-color-background-default);
 }
 
@@ -171,12 +171,12 @@
     display: none;
   }
 
-  .field[data-collapsible="true"] {
+  .field[data-collapsible] {
     width: 100%;
   }
 
-  .field[data-collapsible="true"] .input,
-  .field[data-collapsible="true"] .hiddenInput {
+  .field[data-collapsible] .input,
+  .field[data-collapsible] .hiddenInput {
     max-width: 100%;
   }
 


### PR DESCRIPTION
… element

The updated design system renders FieldBase as a <ds-field> custom element, which serializes boolean props differently than native DOM elements: `true` becomes "" and `false` becomes "false" (rather than being omitted). This broke the `[data-collapsible="true"]` CSS selectors, locking the field at a fixed 25ch width with no expand-on-type animation.

- Switch CSS to `[data-collapsible]` attribute-existence selectors
- Pass `collapsible ? true : undefined` so the attribute is omitted
  entirely when not collapsible

<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Deploy 🚀

- [ ] Deploy Storybook preview
