### PR TITLE
Fix(ResourceListItem): Add new titleBadge

### DIFF
--- a/lib/components/ResourceListItem/ResourceListItem.stories.tsx
+++ b/lib/components/ResourceListItem/ResourceListItem.stories.tsx
@@ -32,6 +32,7 @@ const meta = {
     border: 'none',
     as: 'div',
     titleAs: 'h3',
+    titleBadge: undefined,
   },
   argTypes: {
     size: {
@@ -90,6 +91,15 @@ export const Default: Story = {
         {...args}
         onClick={() => alert(`You clicked me - yay!`)}
       />
+    </List>
+  ),
+  args: {},
+};
+
+export const TitleBadge: Story = {
+  render: (args) => (
+    <List>
+      <ResourceListItem {...args} titleBadge={{ label: 'Arkivert', color: 'neutral', theme: 'subtle' }} />
     </List>
   ),
   args: {},

--- a/lib/components/ResourceListItem/ResourceListItem.tsx
+++ b/lib/components/ResourceListItem/ResourceListItem.tsx
@@ -1,3 +1,4 @@
+import { Badge } from '../Badge';
 import type { BadgeProps } from '../Badge';
 import { ListItem } from '../List';
 import type { ListItemProps } from '../List';
@@ -21,6 +22,8 @@ export interface ResourceListItemProps
   description?: string;
   /** Badge properties for the resource item (optional) */
   badge?: BadgeProps;
+  /** Badge displayed inline next to the title */
+  titleBadge?: BadgeProps;
   /** Title element for the resource item (optional) */
   titleAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'div' | 'span';
 }
@@ -32,8 +35,21 @@ export const ResourceListItem = ({
   ownerLogoUrl,
   description,
   titleAs = 'h3',
+  titleBadge,
+  size,
+  loading,
   ...props
 }: ResourceListItemProps) => {
+  const titleChildren =
+    titleBadge && !loading ? (
+      <>
+        {resourceName}
+        <Badge {...titleBadge} style={{ marginLeft: '0.5em', verticalAlign: 'middle' }} />
+      </>
+    ) : (
+      resourceName
+    );
+
   return (
     <ListItem
       icon={{
@@ -42,8 +58,10 @@ export const ResourceListItem = ({
         imageUrlAlt: ownerLogoUrlAlt,
         type: 'company',
       }}
-      title={{ children: resourceName, as: titleAs }}
+      title={{ children: titleChildren, as: titleAs }}
       description={description ?? ownerName}
+      size={size}
+      loading={loading}
       {...props}
     />
   );

--- a/lib/components/ResourceListItem/resourceListItem.module.css
+++ b/lib/components/ResourceListItem/resourceListItem.module.css
@@ -1,0 +1,14 @@
+.label {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+  overflow: hidden;
+  flex-wrap: wrap;
+}
+
+.label > span {
+  min-width: 0;
+  overflow: hidden;
+}

--- a/package.json
+++ b/package.json
@@ -2,17 +2,11 @@
   "name": "@altinn/altinn-components",
   "version": "0.64.1",
   "main": "dist/index.js",
-  "files": [
-    "dist/",
-    "!dist/stories/",
-    "!dist/components/*/*.stories.js"
-  ],
+  "files": ["dist/", "!dist/stories/", "!dist/components/*/*.stories.js"],
   "types": "dist/types/lib/index.d.ts",
   "type": "module",
   "description": "Reusable react components",
-  "sideEffects": [
-    "*.css"
-  ],
+  "sideEffects": ["*.css"],
   "scripts": {
     "test": "vitest run",
     "test:unit": "vitest run --project=unit",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<img width="1140" height="275" alt="image" src="https://github.com/user-attachments/assets/ce08e413-857c-42bd-bef8-fa00d7e08edf" />

## Description
<!--- Describe your changes in detail -->
Adds new optional titleBadge prop to the ResourceListItem so that a badge can be displayed next to its title

## Deploy 🚀

- [ ] Deploy Storybook preview
