### PR TITLE
feat(Toolbar): add optional htmlTitle for native title attribute on c…

### DIFF
--- a/lib/components/Menu/MenuItem.tsx
+++ b/lib/components/Menu/MenuItem.tsx
@@ -36,6 +36,8 @@ export interface MenuItemProps extends AriaAttributes {
   icon?: IconProps | SvgElement | AvatarProps | AvatarGroupProps;
   /** Title */
   title?: string;
+  /** Advisory text set as the native HTML `title` attribute (tooltip) on the item element. */
+  htmlTitle?: string;
   /** Description */
   description?: string;
   /** Custom label */
@@ -96,6 +98,7 @@ export const MenuItem = ({
   badge,
   controls,
   title,
+  htmlTitle,
   description,
   highlightWords,
   count,
@@ -131,6 +134,7 @@ export const MenuItem = ({
         aria-selected={checked}
         data-selected={checked}
         aria-label={title}
+        title={htmlTitle}
         data-testid={dataTestId}
         onKeyUp={(e: KeyboardEvent) => {
           if (disabled) return;
@@ -201,6 +205,7 @@ export const MenuItem = ({
       aria-selected={role === 'option' ? selected : undefined}
       data-selected={selected}
       aria-label={title}
+      title={htmlTitle}
       data-testid={dataTestId}
       onKeyUp={(e: KeyboardEvent) => {
         if (disabled) return;

--- a/lib/components/Toolbar/Toolbar.stories.tsx
+++ b/lib/components/Toolbar/Toolbar.stories.tsx
@@ -93,6 +93,65 @@ export const Composition = () => {
   );
 };
 
+export const WithHtmlTitle = () => {
+  return (
+    <Toolbar>
+      <ToolbarMenu
+        label="Menu"
+        htmlTitle="Velg en handling fra menyen"
+        items={[{ title: 'MenuItem 1' }, { title: 'MenuItem 2' }, { title: 'MenuItem 3' }]}
+      />
+      <ToolbarSearch name="search" placeholder="Search" htmlTitle="Søk i innboksen" />
+      <ToolbarFilter
+        filterState={{}}
+        filters={[
+          {
+            label: 'Filter 1',
+            name: 'f1',
+            htmlTitle: 'Filtrer på alternativ',
+            items: [
+              {
+                role: 'radio',
+                name: 'f1',
+                htmlTitle: 'valg 1',
+                value: '1',
+                label: 'Filter 1',
+              },
+              {
+                role: 'radio',
+                name: 'f1',
+                value: '2',
+                htmlTitle: 'valg 2',
+                label: 'Filter 2',
+              },
+            ],
+          },
+          {
+            label: 'Filter 2',
+            name: 'f2',
+            htmlTitle: 'Filtrer på flere alternativer',
+            removable: true,
+            items: [
+              {
+                role: 'checkbox',
+                name: 'f2',
+                value: '1',
+                label: 'Filter 1',
+              },
+              {
+                role: 'checkbox',
+                name: 'f2',
+                value: '2',
+                label: 'Filter 2',
+              },
+            ],
+          },
+        ]}
+      />
+    </Toolbar>
+  );
+};
+
 export const SearchAndFilter = () => {
   return (
     <Toolbar>

--- a/lib/components/Toolbar/ToolbarFilterButton.tsx
+++ b/lib/components/Toolbar/ToolbarFilterButton.tsx
@@ -15,6 +15,8 @@ interface ToolbarFilterButtonProps {
   menuId?: string;
   ref?: React.Ref<HTMLButtonElement>;
   variant?: ButtonProps['variant'];
+  /** Advisory text set as the native HTML `title` attribute (tooltip) on the filter button. */
+  htmlTitle?: string;
 }
 
 export function ToolbarFilterButton({
@@ -28,11 +30,19 @@ export function ToolbarFilterButton({
   open,
   variant,
   ref,
+  htmlTitle,
 }: ToolbarFilterButtonProps) {
   if (removable) {
     return (
       <ButtonGroup disabled={disabled} variant={variant} connected>
-        <Button variant={variant} onClick={onClick} data-id={`filter-button-${name}`} aria-expanded={open} ref={ref}>
+        <Button
+          variant={variant}
+          onClick={onClick}
+          data-id={`filter-button-${name}`}
+          aria-expanded={open}
+          title={htmlTitle}
+          ref={ref}
+        >
           <span>{children}</span>
         </Button>
         <ButtonGroupDivider variant={variant} />
@@ -53,7 +63,7 @@ export function ToolbarFilterButton({
   }
 
   return (
-    <Button disabled={disabled} variant={variant} onClick={onClick} data-id={`filter-button-${name}`}>
+    <Button disabled={disabled} variant={variant} onClick={onClick} data-id={`filter-button-${name}`} title={htmlTitle}>
       <span>{children}</span>
       <ChevronUpDownIcon />
     </Button>

--- a/lib/components/Toolbar/ToolbarFilterMenu.tsx
+++ b/lib/components/Toolbar/ToolbarFilterMenu.tsx
@@ -45,6 +45,7 @@ export const ToolbarFilterMenu = ({
   search,
   virtualized,
   title,
+  htmlTitle,
   variant: customVariant,
   dropdownSize = 'sm',
 }: ToolbarFilterMenuProps) => {
@@ -101,6 +102,7 @@ export const ToolbarFilterMenu = ({
         variant={customVariant || variant}
         removeLabel={removeLabel}
         open={open}
+        htmlTitle={htmlTitle}
       >
         {label}
       </ToolbarFilterButton>
@@ -123,6 +125,7 @@ export const ToolbarFilterMenu = ({
             variant={customVariant || variant}
             removeLabel={removeLabel}
             open={open}
+            htmlTitle={htmlTitle}
             aria-expanded={open}
             aria-controls={ctrl.menuId}
             ref={ctrl.triggerRef as React.Ref<HTMLButtonElement>}
@@ -160,7 +163,7 @@ export const ToolbarFilterMenu = ({
       variant="drawer-dropdown"
       submitLabel={submitLabel}
       trigger={
-        <ToolbarFilterButton name={name} onClick={onToggle} variant={customVariant || variant}>
+        <ToolbarFilterButton name={name} onClick={onToggle} variant={customVariant || variant} htmlTitle={htmlTitle}>
           {label}
         </ToolbarFilterButton>
       }

--- a/lib/components/Toolbar/ToolbarMenu.tsx
+++ b/lib/components/Toolbar/ToolbarMenu.tsx
@@ -9,6 +9,8 @@ import styles from './toolbarMenu.module.css';
 export interface ToolbarMenuProps extends Omit<MenuProps, 'variant'> {
   disabled?: boolean;
   title?: string;
+  /** Advisory text set as the native HTML `title` attribute (tooltip) on the trigger button. */
+  htmlTitle?: string;
   label?: string;
   variant?: ButtonProps['variant'];
   dropdownSize?: DropdownProps['size'];
@@ -21,6 +23,7 @@ export const ToolbarMenu = memo(
     label = 'Label',
     variant = 'solid',
     title = 'Title',
+    htmlTitle,
     items = [],
     dropdownSize = 'sm',
     id = 'toolbar-menu',
@@ -47,7 +50,7 @@ export const ToolbarMenu = memo(
 
     if (disabled) {
       return (
-        <Button className={styles.button} variant={variant} disabled>
+        <Button className={styles.button} variant={variant} title={htmlTitle} disabled>
           <span className={styles.label}>{label}</span>
           <ChevronUpDownIcon aria-hidden="true" focusable="false" />
         </Button>
@@ -65,6 +68,7 @@ export const ToolbarMenu = memo(
             <Button
               className={styles.button}
               variant={variant}
+              title={htmlTitle}
               onClick={ctrl.toggleMenu}
               aria-expanded={ctrl.open}
               aria-haspopup="menu"

--- a/lib/components/Toolbar/ToolbarSearch.tsx
+++ b/lib/components/Toolbar/ToolbarSearch.tsx
@@ -3,6 +3,8 @@ import { SearchField, type SearchFieldProps } from '../Forms';
 
 export interface ToolbarSearchProps extends SearchFieldProps {
   collapsible?: boolean;
+  /** Advisory text set as the native HTML `title` attribute (tooltip) on the search input. */
+  htmlTitle?: string;
 }
 
 export const ToolbarSearch = memo(
@@ -21,6 +23,7 @@ export const ToolbarSearch = memo(
     menu,
     minLength,
     disabled,
+    htmlTitle,
   }: ToolbarSearchProps) => {
     return (
       <SearchField
@@ -29,6 +32,7 @@ export const ToolbarSearch = memo(
         hideLabel={hideLabel}
         value={value}
         name={name}
+        title={htmlTitle}
         placeholder={placeholder}
         clearButtonAltText={clearButtonAltText}
         onChange={onChange}

--- a/lib/components/Toolbar/useFilter.tsx
+++ b/lib/components/Toolbar/useFilter.tsx
@@ -17,6 +17,8 @@ export interface FilterProps extends Omit<MenuProps, 'variant'> {
   icon?: MenuItemProps['icon'];
   label?: string;
   title?: MenuItemProps['title'];
+  /** Advisory text set as the native HTML `title` attribute (tooltip) on the filter button. */
+  htmlTitle?: string;
   description?: MenuItemProps['description'];
   removable?: boolean;
   groups?: FilterGroups;

--- a/package.json
+++ b/package.json
@@ -2,17 +2,11 @@
   "name": "@altinn/altinn-components",
   "version": "0.65.0",
   "main": "dist/index.js",
-  "files": [
-    "dist/",
-    "!dist/stories/",
-    "!dist/components/*/*.stories.js"
-  ],
+  "files": ["dist/", "!dist/stories/", "!dist/components/*/*.stories.js"],
   "types": "dist/types/lib/index.d.ts",
   "type": "module",
   "description": "Reusable react components",
-  "sideEffects": [
-    "*.css"
-  ],
+  "sideEffects": ["*.css"],
   "scripts": {
     "test": "vitest run",
     "test:unit": "vitest run --project=unit",


### PR DESCRIPTION
…ontrols

Adds an optional `htmlTitle` prop to the elements the Toolbar is built from, applied as the native HTML `title=""` attribute (advisory tooltip) on the underlying button/input. Kept separate from the existing `title` prop, which is the dropdown heading / menu label text.


<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Deploy 🚀

- [ ] Deploy Storybook preview
