### PR TITLE
fix(modal): close dismissable dialogs on Escape via native cancel event

### DIFF
--- a/lib/components/GlobalHeader/HeaderDrawer.tsx
+++ b/lib/components/GlobalHeader/HeaderDrawer.tsx
@@ -32,24 +32,16 @@ export const HeaderDrawer = ({
 
   useEffect(() => {
     const dialog = dialogRef.current;
-    const handleClosedby = (event: Event) => {
-      const { clientY: y, clientX: x, target } = event as MouseEvent;
-      if (event instanceof KeyboardEvent) {
-        if (event.key === 'Escape') {
-          if (closedBy === 'none') {
-            event.preventDefault();
-            return;
-          }
-          onClose();
-          return;
-        }
-      }
+    // Light dismiss: close when the backdrop (the dialog element itself) is
+    // clicked. Escape is handled natively via the dialog "cancel" event.
+    const handleBackdropClick = (event: MouseEvent) => {
       if (window.getSelection()?.toString()) return;
+      const { clientY: y, clientX: x, target } = event;
       if (dialog && target === dialog && closedBy === 'any') {
         const { top, left, right, bottom } = dialog.getBoundingClientRect();
         const isInDialog = top <= y && y <= bottom && left <= x && x <= right;
 
-        if (!isInDialog) dialog?.close();
+        if (!isInDialog) dialog.close();
       }
     };
 
@@ -59,14 +51,12 @@ export const HeaderDrawer = ({
     };
 
     dialog?.addEventListener('animationend', handleAutoFocus);
-    dialog?.addEventListener('click', handleClosedby);
-    dialog?.addEventListener('keydown', handleClosedby);
+    dialog?.addEventListener('click', handleBackdropClick);
     return () => {
       dialog?.removeEventListener('animationend', handleAutoFocus);
-      dialog?.removeEventListener('click', handleClosedby);
-      dialog?.removeEventListener('keydown', handleClosedby);
+      dialog?.removeEventListener('click', handleBackdropClick);
     };
-  }, [closedBy, onClose]);
+  }, [closedBy]);
 
   useEffect(() => {
     const dialog = dialogRef.current;
@@ -84,8 +74,11 @@ export const HeaderDrawer = ({
   }, [open]);
 
   const handleCancel = (e: React.SyntheticEvent<HTMLDialogElement>) => {
-    e.preventDefault();
-    closedBy === 'any' && onClose();
+    // The "cancel" event fires on Escape (a close request). Block it only when
+    // the dialog must not be dismissed; otherwise let it close natively, which
+    // notifies the parent through the "close" event (onClose) and restores
+    // focus to the element that opened the dialog.
+    if (closedBy === 'none') e.preventDefault();
   };
 
   return (

--- a/lib/components/Modal/ModalBase.tsx
+++ b/lib/components/Modal/ModalBase.tsx
@@ -36,24 +36,16 @@ export const ModalBase = ({
 
   useEffect(() => {
     const dialog = dialogRef.current;
-    const handleClosedby = (event: Event) => {
-      const { clientY: y, clientX: x, target } = event as MouseEvent;
-      if (event instanceof KeyboardEvent) {
-        if (event.key === 'Escape') {
-          if (closedBy === 'none') {
-            event.preventDefault();
-            return;
-          }
-          onClose();
-          return;
-        }
-      }
+    // Light dismiss: close when the backdrop (the dialog element itself) is
+    // clicked. Escape is handled natively via the dialog "cancel" event.
+    const handleBackdropClick = (event: MouseEvent) => {
       if (window.getSelection()?.toString()) return;
+      const { clientY: y, clientX: x, target } = event;
       if (dialog && target === dialog && closedBy === 'any') {
         const { top, left, right, bottom } = dialog.getBoundingClientRect();
         const isInDialog = top <= y && y <= bottom && left <= x && x <= right;
 
-        if (!isInDialog) dialog?.close();
+        if (!isInDialog) dialog.close();
       }
     };
 
@@ -63,14 +55,12 @@ export const ModalBase = ({
     };
 
     dialog?.addEventListener('animationend', handleAutoFocus);
-    dialog?.addEventListener('click', handleClosedby);
-    dialog?.addEventListener('keydown', handleClosedby);
+    dialog?.addEventListener('click', handleBackdropClick);
     return () => {
       dialog?.removeEventListener('animationend', handleAutoFocus);
-      dialog?.removeEventListener('click', handleClosedby);
-      dialog?.removeEventListener('keydown', handleClosedby);
+      dialog?.removeEventListener('click', handleBackdropClick);
     };
-  }, [closedBy, onClose]);
+  }, [closedBy]);
 
   useEffect(() => {
     const dialog = dialogRef.current;
@@ -88,8 +78,8 @@ export const ModalBase = ({
   }, [open]);
 
   const handleCancel = (e: React.SyntheticEvent<HTMLDialogElement>) => {
-    e.preventDefault();
-    closedBy === 'any' && onClose();
+    /* The "cancel" event fires on Escape (a close request). Block it only when the dialog must not be dismissed; */
+    if (closedBy === 'none') e.preventDefault();
   };
 
   return (

--- a/package.json
+++ b/package.json
@@ -2,17 +2,11 @@
   "name": "@altinn/altinn-components",
   "version": "0.67.2",
   "main": "dist/index.js",
-  "files": [
-    "dist/",
-    "!dist/stories/",
-    "!dist/components/*/*.stories.js"
-  ],
+  "files": ["dist/", "!dist/stories/", "!dist/components/*/*.stories.js"],
   "types": "dist/types/lib/index.d.ts",
   "type": "module",
   "description": "Reusable react components",
-  "sideEffects": [
-    "*.css"
-  ],
+  "sideEffects": ["*.css"],
   "scripts": {
     "test": "vitest run",
     "test:unit": "vitest run --project=unit",


### PR DESCRIPTION
Lukkbare modaler lukkes nå riktig med Escape (og gir fokus tilbake til knappen som åpnet dem), i stedet for å bli stående åpne og ta fokus selv, og vilkårlige tastetrykk lukker dem ikke lenger.

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
https://github.com/Altinn/dialogporten-frontend/issues/4285

## Deploy 🚀

- [ ] Deploy Storybook preview
