### PR TITLE
fix(header): scroll to correct position when opening account/menu drawer

### DIFF
--- a/lib/components/AccountSelector/AccountSelector.tsx
+++ b/lib/components/AccountSelector/AccountSelector.tsx
@@ -105,6 +105,11 @@ export const AccountSelector = ({
               onChange={(e) => setSearchString(e.target.value)}
               onClear={() => setSearchString('')}
               className={styles.searchField}
+              onBlur={() => {
+                requestAnimationFrame(() => {
+                  window.scrollTo({ top: -window.scrollY, behavior: 'instant' });
+                });
+              }}
             />
           )}
           {showDeletedToggle && (

--- a/lib/components/GlobalHeader/GlobalHeader.tsx
+++ b/lib/components/GlobalHeader/GlobalHeader.tsx
@@ -39,23 +39,25 @@ export const GlobalHeader = ({
   onLoginClick,
 }: GlobalHeaderProps) => {
   const { currentId, toggleId, closeAll } = useRootContext();
+  const isDesktop = useIsDesktop();
 
   const onToggleAccountMenu = () => {
-    if (currentId !== 'account') {
-      window.scrollTo({ top: 0, behavior: 'instant' });
-    }
+    requestAnimationFrame(() => {
+      window.scrollTo({ top: -window.scrollY, behavior: 'instant' });
+    });
     toggleId('account');
   };
 
   const onToggleMenu = () => {
     toggleId('menu');
+    requestAnimationFrame(() => {
+      window.scrollTo({ top: -window.scrollY, behavior: 'instant' });
+    });
   };
 
   const accountSelectionOpen = currentId === 'account' || accountSelector?.forceOpenFullScreen || false;
 
   const [expanded, setExpanded] = useState(false);
-
-  const isDesktop = useIsDesktop();
 
   return (
     <header className={styles.header} data-current-id={currentId}>


### PR DESCRIPTION
**Problem**: The account selector and global menu open are anchored as `position:fixed` just below the header. When the page was scrolled, the static top offset no longer matched the header's real position, leaving a gap between the header and the drawer. Scroll to the top whenever either drawer opens so they stay attached (on the first open too). Top: 0 (previously was incorrect, it should scroll to the offset of Y to reset... then this will work no matter what content is above, e.g. banner / no banner). 

Also reset the scroll on the account search field's blur: iOS Safari doesn't restore the scroll position after the soft keyboard is dismissed, which re-introduced the gap. All scrolls run in requestAnimationFrame so they apply after the browser's own focus/viewport adjustments.


## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Deploy 🚀

- [x] Deploy Storybook preview
