### PR TITLE
fix: Remove ariaLabel from ListItem in AccessAreaListItem

### DIFF
--- a/lib/components/AccessAreaListItem/AccessAreaListItem.tsx
+++ b/lib/components/AccessAreaListItem/AccessAreaListItem.tsx
@@ -52,7 +52,6 @@ export const AccessAreaListItem = ({
       as="button"
       icon={themedIcon}
       title={{ children: name, as: titleAs }}
-      ariaLabel={name}
       size={size}
       collapsible={!loading}
       expanded={expanded}


### PR DESCRIPTION
## Description
- Removed ariaLabel prop from ListItem component, rely on `title` instead. Having ariaLabel set, causes screen reader to not identify heading level of title

## Related Issue(s)
- part of https://github.com/Altinn/altinn-authorization-tmp/issues/3135

## Deploy 🚀

- [ ] Deploy Storybook preview
