### PR TITLE
fix: extend formatDisplayName heuristics

### DIFF
--- a/lib/functions/name/name.spec.ts
+++ b/lib/functions/name/name.spec.ts
@@ -56,8 +56,29 @@ describe('formatDisplayName', () => {
     expect(formatDisplayName({ fullName: 'test.company AS', type: 'company' })).toBe('Test.company AS');
   });
 
-  it('does not affect person names with periods', () => {
-    expect(formatDisplayName({ fullName: 'TEST A.B.C', type: 'person' })).toBe('Test A.b.c');
+  it('preserves and uppercases initials in person names', () => {
+    expect(formatDisplayName({ fullName: 'TEST A.B.C', type: 'person' })).toBe('Test A.B.C');
+    expect(formatDisplayName({ fullName: 'ola j. k. nordmann', type: 'person' })).toBe('Ola J. K. Nordmann');
+  });
+
+  describe('legal entity suffixes', () => {
+    it.each(['se', 'fkf', 'kf', 'ks', 'iks', 'gfs', 'sf', 'hf', 'rhf', 'sti'])(
+      'uppercases the "%s" suffix for companies',
+      (suffix) => {
+        expect(formatDisplayName({ fullName: `test ${suffix}`, type: 'company' })).toBe(`Test ${suffix.toUpperCase()}`);
+      },
+    );
+  });
+
+  describe('nobiliary particles', () => {
+    it('lowercases particles when not the first word', () => {
+      expect(formatDisplayName({ fullName: 'CHARLES DE GAULLE', type: 'person' })).toBe('Charles de Gaulle');
+      expect(formatDisplayName({ fullName: 'LUDWIG VAN BEETHOVEN', type: 'person' })).toBe('Ludwig van Beethoven');
+    });
+
+    it('capitalizes a particle when it is the first word', () => {
+      expect(formatDisplayName({ fullName: 'DE GAULLE CHARLES', type: 'person' })).toBe('De Gaulle Charles');
+    });
   });
 
   describe('municipalities (kommuner)', () => {

--- a/lib/functions/name/name.ts
+++ b/lib/functions/name/name.ts
@@ -24,11 +24,33 @@ interface FormatDisplayNameInput {
 export const formatDisplayName = ({ fullName, type, reverseNameOrder }: FormatDisplayNameInput): string => {
   if (!fullName) return '';
 
-  const legalEntityTypes = ['enk', 'as', 'da', 'sa', 'asa', 'ba', 'ans', 'sti', 'nuf'];
+  const legalEntityTypes = [
+    'enk',
+    'as',
+    'da',
+    'sa',
+    'asa',
+    'ba',
+    'ans',
+    'sti',
+    'nuf',
+    'se',
+    'fkf',
+    'kf',
+    'ks',
+    'iks',
+    'gfs',
+    'sf',
+    'hf',
+    'rhf',
+  ];
   // Common Norwegian nouns/conjunctions that should stay lowercase when they
   // appear after the first word, e.g. "Oslo kommune", "Viken fylkeskommune"
   // and "Møre og Romsdal fylkeskommune".
   const lowercaseWords = ['kommune', 'fylkeskommune', 'og'];
+  // Nobiliary particles that stay lowercase when they are not the first word,
+  // e.g. "Charles de Gaulle" or "Ludwig van Beethoven".
+  const nobiliaryParticles = ['von', 'van', 'der', 'de', 'la', 'dos'];
   const parts = fullName.split(' ');
 
   const isAbbreviation = (word: string): boolean => {
@@ -51,8 +73,15 @@ export const formatDisplayName = ({ fullName, type, reverseNameOrder }: FormatDi
       return lowerWord;
     }
 
-    if (type === 'company' && isAbbreviation(word)) {
-      return word;
+    // Keep nobiliary particles lowercase, but never as the first word.
+    if (idx > 0 && nobiliaryParticles.includes(lowerWord)) {
+      return lowerWord;
+    }
+
+    // Preserve initials/abbreviations and write them in uppercase, e.g. "J. K."
+    // or company names like "A.B.C AS".
+    if (isAbbreviation(word)) {
+      return word.toUpperCase();
     }
 
     return lowerWord

--- a/package.json
+++ b/package.json
@@ -2,17 +2,11 @@
   "name": "@altinn/altinn-components",
   "version": "0.68.2",
   "main": "dist/index.js",
-  "files": [
-    "dist/",
-    "!dist/stories/",
-    "!dist/components/*/*.stories.js"
-  ],
+  "files": ["dist/", "!dist/stories/", "!dist/components/*/*.stories.js"],
   "types": "dist/types/lib/index.d.ts",
   "type": "module",
   "description": "Reusable react components",
-  "sideEffects": [
-    "*.css"
-  ],
+  "sideEffects": ["*.css"],
   "scripts": {
     "test": "vitest run",
     "test:unit": "vitest run --project=unit",


### PR DESCRIPTION
- Add missing legal entity suffixes: se, fkf, kf, ks, iks, gfs, sf,
  hf, rhf (keep sti)
- Keep nobiliary particles (von, van, der, de, la, dos) lowercase when
  not the first word, e.g. "Charles de Gaulle"
- Preserve and uppercase initials for person names too, not just
  companies, e.g. "Ola J. K. Nordmann"

<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Deploy 🚀

- [ ] Deploy Storybook preview
