### PR TITLE
fix(menu): use navigation semantics for sidebar instead of role=menu

### DIFF
--- a/lib/components/GlobalMenu/GlobalMenuBase.tsx
+++ b/lib/components/GlobalMenu/GlobalMenuBase.tsx
@@ -14,7 +14,7 @@ export interface GlobalMenuFooterProps {
 export const GlobalMenuBase = forwardRef<HTMLElement, GlobalMenuBaseProps>(({ color, children, ...rest }, ref) => {
   return (
     <nav ref={ref} className={styles.nav} data-color={color} {...rest}>
-      <div role="menu">{children}</div>
+      {children}
     </nav>
   );
 });

--- a/lib/components/Layout/Layout.tsx
+++ b/lib/components/Layout/Layout.tsx
@@ -22,6 +22,8 @@ import styles from './layoutBase.module.css';
 
 interface SidebarProps extends LayoutSidebarProps {
   menu?: MenuProps;
+  /** Accessible label for the sidebar navigation landmark. */
+  ariaLabel?: string;
   children?: ReactNode;
 }
 
@@ -123,7 +125,11 @@ export const Layout = ({
               color={sidebar?.color}
               footer={sidebar?.footer}
             >
-              {sidebar?.menu && <Menu {...sidebar?.menu} />}
+              {sidebar?.menu && (
+                <nav aria-label={sidebar?.ariaLabel ?? 'Sidebar'}>
+                  <Menu {...sidebar?.menu} a11yMode="navigation" />
+                </nav>
+              )}
               {sidebar?.children}
             </LayoutSidebar>
           )}

--- a/lib/components/Menu/MenuItem.tsx
+++ b/lib/components/Menu/MenuItem.tsx
@@ -25,6 +25,8 @@ export interface MenuItemProps extends AriaAttributes {
   id?: string;
   groupId?: string;
   role?: MenuItemRole;
+  /** @internal a11y context set by the parent list. In `navigation` mode the item renders without a menu role. */
+  a11yMode?: 'menu' | 'combobox' | 'navigation';
   as?: ElementType;
   /** Size, default is sm */
   size?: MenuItemSize;
@@ -81,6 +83,7 @@ export const MenuItem = ({
   id,
   groupId,
   role = 'menuItem',
+  a11yMode,
   as,
   href,
   onClick,
@@ -210,7 +213,7 @@ export const MenuItem = ({
       onClick={onClick}
       onMouseEnter={onMouseEnter}
       tabIndex={disabled ? -1 : (tabIndex ?? 0)}
-      role={role === 'menuItem' ? 'menuitem' : role}
+      role={a11yMode === 'navigation' ? undefined : role === 'menuItem' ? 'menuitem' : role}
       {...ariaProps}
     >
       {icon && <ItemMedia icon={icon} className={styles.media} />}

--- a/lib/components/Menu/MenuItems.tsx
+++ b/lib/components/Menu/MenuItems.tsx
@@ -21,7 +21,7 @@ export interface MenuItemsProps {
   level?: number;
   maxLevels?: number;
   expanded?: boolean;
-  a11yMode?: 'menu' | 'combobox';
+  a11yMode?: 'menu' | 'combobox' | 'navigation';
   open?: boolean;
   scrollToTopOnOpen?: boolean;
   autoActivateFirstItem?: boolean;
@@ -68,6 +68,7 @@ export const MenuItems = ({
   }
 
   const isCombobox = a11yMode === 'combobox';
+  const isNavigation = a11yMode === 'navigation';
   const listId = isCombobox && id ? `${id}-listbox` : id;
   const prevOpenRef = useRef<boolean | undefined>(open);
   const prevFocusOpenRef = useRef<boolean | undefined>(open);
@@ -171,7 +172,7 @@ export const MenuItems = ({
       ref={ref}
       style={scrollRefStyles}
       id={listId}
-      role={isCombobox ? 'listbox' : 'menu'}
+      role={isCombobox ? 'listbox' : isNavigation ? 'list' : 'menu'}
       tabIndex={keyboardEvents ? -1 : undefined}
     >
       {!isCombobox && searchElement}
@@ -194,13 +195,19 @@ export const MenuItems = ({
                     const hasSubmenu = Array.isArray(itemProps?.items) && itemProps.items.length > 0;
                     const isCheckable = itemProps.role === 'checkbox' || itemProps.role === 'radio';
                     const menuCheckableRole = itemProps.role === 'radio' ? 'menuitemradio' : 'menuitemcheckbox';
-                    const resolvedRole = isCombobox ? 'option' : isCheckable ? menuCheckableRole : itemProps.role;
+                    const resolvedRole = isNavigation
+                      ? undefined
+                      : isCombobox
+                        ? 'option'
+                        : isCheckable
+                          ? menuCheckableRole
+                          : itemProps.role;
                     return (
                       <MenuListItem
                         key={index}
                         expanded={expanded}
                         onMouseLeave={() => setActiveIndex(-1)}
-                        role="presentation"
+                        role={isNavigation ? 'listitem' : 'presentation'}
                       >
                         <MenuItem
                           {...itemProps}
@@ -209,10 +216,11 @@ export const MenuItems = ({
                           variant={itemProps?.variant || groupProps?.variant || variant}
                           active={active}
                           role={resolvedRole}
+                          a11yMode={a11yMode}
                           selected={itemProps.selected}
                           tabIndex={itemProps?.disabled || keyboardEvents ? -1 : (itemProps.tabIndex ?? 0)}
                           onMouseEnter={onMouseEnter}
-                          aria-haspopup={hasSubmenu ? 'menu' : undefined}
+                          aria-haspopup={hasSubmenu && !isNavigation ? 'menu' : undefined}
                           aria-expanded={hasSubmenu ? expanded : undefined}
                           aria-controls={hasSubmenu ? itemProps.id + '-menu' : undefined}
                         />
@@ -227,6 +235,7 @@ export const MenuItems = ({
                             size={size}
                             color={color}
                             variant={variant}
+                            a11yMode={a11yMode}
                           />
                         )}
                       </MenuListItem>

--- a/lib/components/Menu/VirtualizedMenuItems.tsx
+++ b/lib/components/Menu/VirtualizedMenuItems.tsx
@@ -35,6 +35,7 @@ export const VirtualizedMenuItems = (props: MenuItemsProps) => {
   } = props;
 
   const isCombobox = a11yMode === 'combobox';
+  const isNavigation = a11yMode === 'navigation';
   const listId = isCombobox && id ? `${id}-listbox` : id;
   const prevOpenRef = useRef<boolean | undefined>(open);
   const [isListNavigationActive, setIsListNavigationActive] = useState(false);
@@ -208,7 +209,7 @@ export const VirtualizedMenuItems = (props: MenuItemsProps) => {
       color={color}
       expanded={expanded}
       id={listId}
-      role={isCombobox ? 'listbox' : 'menu'}
+      role={isCombobox ? 'listbox' : isNavigation ? 'list' : 'menu'}
     >
       {!isCombobox && searchElement}
 
@@ -256,9 +257,15 @@ export const VirtualizedMenuItems = (props: MenuItemsProps) => {
               default: {
                 const isCheckable = entry.itemProps?.role === 'checkbox' || entry.itemProps?.role === 'radio';
                 const menuCheckableRole = entry.itemProps?.role === 'radio' ? 'menuitemradio' : 'menuitemcheckbox';
-                const resolvedRole = isCombobox ? 'option' : isCheckable ? menuCheckableRole : entry.itemProps?.role;
+                const resolvedRole = isNavigation
+                  ? undefined
+                  : isCombobox
+                    ? 'option'
+                    : isCheckable
+                      ? menuCheckableRole
+                      : entry.itemProps?.role;
                 return (
-                  <MenuListItem key={virtualRow.key} {...commonProps} role="presentation">
+                  <MenuListItem key={virtualRow.key} {...commonProps} role={isNavigation ? 'listitem' : 'presentation'}>
                     <MenuItem
                       {...(entry.itemProps || {})}
                       size={entry.itemProps?.size || size}
@@ -266,6 +273,7 @@ export const VirtualizedMenuItems = (props: MenuItemsProps) => {
                       variant={entry.itemProps?.variant || variant}
                       active={entry.active}
                       role={resolvedRole}
+                      a11yMode={a11yMode}
                       selected={entry.itemProps?.selected}
                       aria-posinset={isCombobox ? itemPositions.positions.get(virtualRow.index) : undefined}
                       aria-setsize={isCombobox ? itemPositions.total : undefined}

--- a/package.json
+++ b/package.json
@@ -2,17 +2,11 @@
   "name": "@altinn/altinn-components",
   "version": "0.68.3",
   "main": "dist/index.js",
-  "files": [
-    "dist/",
-    "!dist/stories/",
-    "!dist/components/*/*.stories.js"
-  ],
+  "files": ["dist/", "!dist/stories/", "!dist/components/*/*.stories.js"],
   "types": "dist/types/lib/index.d.ts",
   "type": "module",
   "description": "Reusable react components",
-  "sideEffects": [
-    "*.css"
-  ],
+  "sideEffects": ["*.css"],
   "scripts": {
     "test": "vitest run",
     "test:unit": "vitest run --project=unit",


### PR DESCRIPTION
Den permanente sidebar-menyen brukte role="menu"/role="menuitem", som er ment for midlertidige popup-menyer. Det gjorde at skjermlesere flyttet fokus til sidebaren når en dialog lukket (i stedet for tilbake til
triggeren), og leste opp menu-rollen dobbelt.

- Ny a11yMode="navigation" på Menu: lista blir role="list" med rene
  link/button-elementer (ingen role="menuitem") og uten aria-haspopup="menu".
- Sidebar-menyen pakkes i et <nav>-landemerke i navigation-modus; ny
  SidebarProps.ariaLabel.
- Fjernet overflødig <div role="menu"> i GlobalMenuBase, så global-menyen
  ikke leses opp som meny to ganger.

ContextMenu og ToolbarMenu er urørt og beholder role="menu", siden de er
ekte popup-menyer åpnet fra en trigger med aria-haspopup.

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Deploy 🚀

- [x] Deploy Storybook preview
