### PR TITLE
fix: add minimal polyfill for popover to Snackbar component

### DIFF
--- a/lib/components/Snackbar/Snackbar.tsx
+++ b/lib/components/Snackbar/Snackbar.tsx
@@ -3,6 +3,13 @@ import { useEffect, useRef } from 'react';
 import { SnackbarBase } from './SnackbarBase.tsx';
 import { SnackbarItem } from './SnackbarItem';
 import { useSnackbar } from './useSnackbar';
+import {
+  isSupported,
+  apply as polyfillPopover,
+} from '@oddbird/popover-polyfill/fn';
+
+const isBrowser = () => typeof window !== 'undefined' && typeof document !== 'undefined';
+if (isBrowser() && !isSupported()) polyfillPopover();
 
 export interface SnackbarProps {
   /** Optional classname */

--- a/lib/components/Snackbar/Snackbar.tsx
+++ b/lib/components/Snackbar/Snackbar.tsx
@@ -1,12 +1,9 @@
 'use client';
+import { isSupported, apply as polyfillPopover } from '@oddbird/popover-polyfill/fn';
 import { useEffect, useRef } from 'react';
 import { SnackbarBase } from './SnackbarBase.tsx';
 import { SnackbarItem } from './SnackbarItem';
 import { useSnackbar } from './useSnackbar';
-import {
-  isSupported,
-  apply as polyfillPopover,
-} from '@oddbird/popover-polyfill/fn';
 
 const isBrowser = () => typeof window !== 'undefined' && typeof document !== 'undefined';
 if (isBrowser() && !isSupported()) polyfillPopover();

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@chromatic-com/storybook": "5.2.1",
+    "@oddbird/popover-polyfill": "0.6.1",
     "@storybook/addon-a11y": "10.4.1",
     "@storybook/addon-docs": "10.4.1",
     "@storybook/addon-themes": "10.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@chromatic-com/storybook':
         specifier: 5.2.1
         version: 5.2.1(storybook@10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+      '@oddbird/popover-polyfill':
+        specifier: 0.6.1
+        version: 0.6.1
       '@storybook/addon-a11y':
         specifier: 10.4.1
         version: 10.4.1(storybook@10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
@@ -625,6 +628,9 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@oddbird/popover-polyfill@0.6.1':
+    resolution: {integrity: sha512-Papau51NPG+NajXvoEHCNT1CBJv4WIyvIGfH5gpJPLL8MZJt/4giC0jJ/mNZRtJmdzRuXWpUFB6QxkJa1RvMAQ==}
 
   '@oxc-parser/binding-android-arm-eabi@0.127.0':
     resolution: {integrity: sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==}
@@ -3246,6 +3252,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@oddbird/popover-polyfill@0.6.1': {}
 
   '@oxc-parser/binding-android-arm-eabi@0.127.0':
     optional: true


### PR DESCRIPTION
## Description
- Add minimal polyfill for popover to Snackbar component to support older browsers. This is the [same polyfill](https://github.com/digdir/designsystemet/pull/4983) used by designsystemet for their popover component.

## Related Issue(s)
- https://github.com/Altinn/altinn-components/issues/1282

## Deploy 🚀

- [x] Deploy Storybook preview
