### PR TITLE
fix(AccessPackageListItem): remove hardcoded aria-label

### DIFF
--- a/lib/components/AccessPackageListItem/AccessPackageListItem.stories.tsx
+++ b/lib/components/AccessPackageListItem/AccessPackageListItem.stories.tsx
@@ -73,7 +73,7 @@ export default meta;
 export const AccessPackageListStory = (args: AccessPackageListItemProps) => {
   return (
     <List>
-      <AccessPackageListItem {...args} description={"3 tjenester"} badge={"NY"}/>
+      <AccessPackageListItem {...args} description={"3 tjenester"} />
     </List>
   );
 };

--- a/lib/components/AccessPackageListItem/AccessPackageListItem.stories.tsx
+++ b/lib/components/AccessPackageListItem/AccessPackageListItem.stories.tsx
@@ -73,7 +73,7 @@ export default meta;
 export const AccessPackageListStory = (args: AccessPackageListItemProps) => {
   return (
     <List>
-      <AccessPackageListItem {...args} />
+      <AccessPackageListItem {...args} description={"3 tjenester"} badge={"NY"}/>
     </List>
   );
 };

--- a/lib/components/AccessPackageListItem/AccessPackageListItem.stories.tsx
+++ b/lib/components/AccessPackageListItem/AccessPackageListItem.stories.tsx
@@ -73,7 +73,7 @@ export default meta;
 export const AccessPackageListStory = (args: AccessPackageListItemProps) => {
   return (
     <List>
-      <AccessPackageListItem {...args} description={"3 tjenester"} />
+      <AccessPackageListItem {...args} description={'3 tjenester'} />
     </List>
   );
 };

--- a/lib/components/AccessPackageListItem/AccessPackageListItem.tsx
+++ b/lib/components/AccessPackageListItem/AccessPackageListItem.tsx
@@ -36,7 +36,6 @@ export const AccessPackageListItem = ({
       icon={PackageIcon}
       as={as}
       title={{ children: name, as: titleAs }}
-      ariaLabel={name}
       color={color}
       size={size}
       variant={variant}


### PR DESCRIPTION
## Description
- Remove hardcoded aria-label from `AccessPackageListItem`. This allows screen readers to also read the description text

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/3340

## Deploy 🚀

- [ ] Deploy Storybook preview
