### PR TITLE
fix: set aria-hidden=true on Icon with iconUrl if altText is not set

### DIFF
--- a/lib/components/Icon/Icon.tsx
+++ b/lib/components/Icon/Icon.tsx
@@ -41,7 +41,7 @@ export const Icon = ({
       <Skeleton loading={loading} variant="circle" className={styles.shape}>
         <span className={styles.shape} />
         {SvgElement && <SvgElement aria-hidden="true" alt-label={altText} className={styles.svg} />}
-        {iconUrl && <img src={iconUrl} alt={altText} className={styles.image} />}
+        {iconUrl && <img src={iconUrl} alt={altText} aria-hidden={!altText} className={styles.image} />}
         {children}
       </Skeleton>
     </span>


### PR DESCRIPTION
## Description
- When using `Icon` component with iconUrl, set aria-hidden on the img tag if altText is not set in props

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/3133

## Deploy 🚀

- [ ] Deploy Storybook preview
