### PR TITLE
fix: Move dialog details modal buttons

### DIFF
--- a/examples/inbox/dialogBody.tsx
+++ b/examples/inbox/dialogBody.tsx
@@ -47,4 +47,10 @@ export const dialogBody: DialogBodyProps = {
       },
     ],
   },
+  activityLog: {
+    label: 'Aktivitetslogg',
+  },
+  accessInfo: {
+    label: 'Om fullmakt og tjeneste',
+  },
 };

--- a/lib/components/Dialog/DialogBody.stories.tsx
+++ b/lib/components/Dialog/DialogBody.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { DialogActions, DialogAttachments, DialogBody } from '..';
+import { useState } from 'react';
+import { DialogActions, DialogAttachments, DialogBody, DialogSeenByLog } from '..';
+import { dialogBody } from '../../../examples';
 
 const meta = {
   title: 'Inbox/Dialog/DialogBody',
@@ -180,4 +182,37 @@ export const WithActions: Story = {
       </>
     ),
   },
+};
+
+export const WithInfoRow = () => {
+  const [seenByLogOpen, setSeenByLogOpen] = useState(false);
+
+  return (
+    <>
+      <DialogBody
+        {...dialogBody}
+        seenByLog={{
+          title: dialogBody.seenByLog?.title,
+          items: dialogBody.seenByLog?.items ?? [],
+          onClick: () => setSeenByLogOpen(true),
+        }}
+        activityLog={{ label: 'Aktivitetslogg', onClick: () => console.log('Aktivitetslogg clicked') }}
+        accessInfo={{ label: 'Om fullmakt og tjeneste', onClick: () => console.log('Om fullmakt og tjeneste clicked') }}
+      >
+        <p>Dialog summary.</p>
+        <DialogActions
+          items={[
+            { id: '1', priority: 'primary', label: 'Primary' },
+            { id: '2', priority: 'secondary', label: 'Secondary' },
+          ]}
+        />
+      </DialogBody>
+      <DialogSeenByLog
+        title="Hvem har sett dialogen?"
+        items={dialogBody.seenByLog?.items ?? []}
+        open={seenByLogOpen}
+        onClose={() => setSeenByLogOpen(false)}
+      />
+    </>
+  );
 };

--- a/lib/components/Dialog/DialogBody.tsx
+++ b/lib/components/Dialog/DialogBody.tsx
@@ -1,10 +1,14 @@
+import { ClockDashedIcon, InformationSquareIcon } from '@navikt/aksel-icons';
 import type { ReactNode } from 'react';
 import styles from './dialogBody.module.css';
 
 import {
   Avatar,
   type AvatarProps,
-  SeenByLog,
+  type DialogMetadataButtonProps,
+  MetaBase,
+  MetaItem,
+  SeenByLogButton,
   type SeenByLogProps,
   Timeline,
   TimelineHeader,
@@ -25,8 +29,12 @@ export interface DialogBodyProps {
   recipientLabel?: string;
   /** Group recipient, show both sender and recipient avatars */
   recipientGroup?: boolean;
-  /** Dialog is seen by the end user or others */
+  /** Dialog is seen by the end user or others. Renders as a trigger button; provide `onClick` to open a modal. */
   seenByLog?: SeenByLogProps;
+  /** Activity log trigger button */
+  activityLog?: DialogMetadataButtonProps;
+  /** "About authorization and service" trigger button */
+  accessInfo?: DialogMetadataButtonProps;
   /** Content */
   children?: ReactNode;
 }
@@ -41,6 +49,8 @@ export const DialogBody = ({
   recipientLabel = 'to',
   children,
   seenByLog,
+  activityLog,
+  accessInfo,
 }: DialogBodyProps) => {
   return (
     <Timeline>
@@ -64,7 +74,25 @@ export const DialogBody = ({
             <Typography maxWidth="60ch" style={{ marginTop: '0.5em' }}>
               {children}
             </Typography>
-            {seenByLog && <SeenByLog {...seenByLog} collapsible={true} />}
+            {(seenByLog || activityLog || accessInfo) && (
+              <MetaBase size="xs">
+                {seenByLog && (
+                  <SeenByLogButton items={seenByLog.items} as="button" onClick={seenByLog.onClick}>
+                    {seenByLog.title}
+                  </SeenByLogButton>
+                )}
+                {activityLog && (
+                  <MetaItem as="button" icon={ClockDashedIcon} onClick={activityLog.onClick}>
+                    {activityLog.label}
+                  </MetaItem>
+                )}
+                {accessInfo && (
+                  <MetaItem as="button" icon={InformationSquareIcon} onClick={accessInfo.onClick}>
+                    {accessInfo.label}
+                  </MetaItem>
+                )}
+              </MetaBase>
+            )}
           </>
         )}
       </TimelineSection>

--- a/lib/components/Dialog/DialogHeader.stories.tsx
+++ b/lib/components/Dialog/DialogHeader.stories.tsx
@@ -85,15 +85,10 @@ export const WithTooltips: Story = {
     },
     sentCount: 1,
     receivedCount: 2,
-    activityLog: {
-      label: 'Aktivitetslogg',
-      onClick: () => alert('Open activity log'),
-    },
     tooltips: {
       sent: 'Sendte meldinger',
       received: 'Meldinger mottatt',
       attachments: 'Vedlegg',
-      activityLog: 'Åpne aktivitetslogg',
     },
   },
 };

--- a/lib/components/Dialog/DialogHeader.tsx
+++ b/lib/components/Dialog/DialogHeader.tsx
@@ -2,7 +2,7 @@ import { Badge, DialogMetadata, type DialogMetadataProps, Heading } from '..';
 
 import styles from './dialogHeader.module.css';
 
-export interface DialogHeaderProps extends DialogMetadataProps {
+export interface DialogHeaderProps extends Omit<DialogMetadataProps, 'activityLog'> {
   /** Loading state */
   loading?: boolean;
   /** Dialog title */
@@ -26,7 +26,6 @@ export const DialogHeader = ({
   archivedAtLabel,
   trashedAt,
   trashedAtLabel,
-  activityLog,
   tooltips = {},
 }: DialogHeaderProps) => {
   return (
@@ -51,7 +50,6 @@ export const DialogHeader = ({
         archivedAt={archivedAt}
         archivedAtLabel={archivedAtLabel}
         attachmentsCount={attachmentsCount}
-        activityLog={activityLog}
         tooltips={tooltips}
       />
     </header>

--- a/lib/components/Dialog/DialogMetadata.tsx
+++ b/lib/components/Dialog/DialogMetadata.tsx
@@ -9,7 +9,7 @@ import {
   TrashFillIcon,
 } from '@navikt/aksel-icons';
 
-interface DialogMetadataButtonProps {
+export interface DialogMetadataButtonProps {
   label: string;
   onClick?: () => void;
 }

--- a/lib/components/Dialog/DialogSeenByLog.tsx
+++ b/lib/components/Dialog/DialogSeenByLog.tsx
@@ -1,0 +1,18 @@
+import { ModalBase, ModalBody, ModalHeader, SeenByLog, type SeenByLogProps } from '../';
+
+export interface DialogSeenByLogProps extends SeenByLogProps {
+  title: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+export const DialogSeenByLog = ({ title, items, endUserLabel, open, onClose }: DialogSeenByLogProps) => {
+  return (
+    <ModalBase open={open} onClose={onClose} variant="content">
+      <ModalHeader title={title} onClose={onClose} />
+      <ModalBody>
+        <SeenByLog items={items} size="md" endUserLabel={endUserLabel} />
+      </ModalBody>
+    </ModalBase>
+  );
+};

--- a/lib/components/Dialog/SeenByLog.tsx
+++ b/lib/components/Dialog/SeenByLog.tsx
@@ -9,6 +9,8 @@ export interface SeenByLogProps {
   items: SeenByLogItemProps[];
   size?: 'sm' | 'md';
   endUserLabel?: string;
+  /** Called when the seen-by trigger is clicked. Used by DialogBody to open a modal instead of expanding inline. */
+  onClick?: () => void;
 }
 
 /**

--- a/lib/components/Dialog/index.ts
+++ b/lib/components/Dialog/index.ts
@@ -22,6 +22,7 @@ export * from './DialogActions';
 export * from './DialogActivityLog';
 
 export * from './DialogSeenBy';
+export * from './DialogSeenByLog';
 export * from './DialogSelect';
 export * from './DialogStatus';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
https://github.com/Altinn/dialogporten-frontend/issues/4283

<img width="566" height="255" alt="Screenshot 2026-07-14 at 12 01 51" src="https://github.com/user-attachments/assets/a10caf37-1ec3-42e2-b795-1b12c3cd3ce5" />


## Deploy 🚀

- [ ] Deploy Storybook preview
