### PR TITLE
Fix(UserListItem): Added deleted badge on deleted items

### DIFF
--- a/lib/components/UserListItem/UserListItem.stories.tsx
+++ b/lib/components/UserListItem/UserListItem.stories.tsx
@@ -354,6 +354,18 @@ export const WithControls = (args: UserListItemProps) => {
       />
       <UserListItem
         {...args}
+        name="Finansmarked AS"
+        type="company"
+        description="Org.nr.: 987654323"
+        roleNames={['Regnskapsfører']}
+        controls={menu('3')}
+        linkIcon={true}
+        onClick={() => alert(`You clicked the link - yay!`)}
+        as={'button'}
+        deleted={true}
+      />
+      <UserListItem
+        {...args}
         name="Hal 9000"
         type="system"
         description="fra Odyssey Inc."

--- a/lib/components/UserListItem/UserListItem.tsx
+++ b/lib/components/UserListItem/UserListItem.tsx
@@ -1,3 +1,4 @@
+import { useRootContext } from '../..';
 import { Badge } from '../Badge';
 import { ListItem, ListItemLabel } from '../List';
 import type { ListItemProps } from '../List';
@@ -53,6 +54,8 @@ export const UserListItem = ({
   deleted = false,
   ...props
 }: UserListItemProps) => {
+  const { languageCode } = useRootContext();
+  const texts = getTexts(languageCode);
   const icon = {
     name: name,
     type: type,
@@ -83,5 +86,30 @@ export const UserListItem = ({
     </div>
   );
 
-  return <ListItem icon={icon} ariaLabel={name} label={label} description={description} loading={loading} {...props} />;
+  const deletedBadge = deleted ? (
+    <div>
+      <Badge label={texts.deleted} color="neutral"/>
+    </div>
+  ) : null;
+
+  return <ListItem icon={icon} ariaLabel={name} label={label} description={description} loading={loading} badge={deletedBadge} {...props} />;
+};
+
+// TODO: Move to a common texts files when i18next is added
+// This is only a temporary solution for providing texts in different languages in a very simple POC
+const getTexts = (languageCode: string | undefined) => {
+  switch (languageCode) {
+    case 'nn':
+      return {
+        deleted: 'Sletta',
+      };
+    case 'en':
+      return {
+        deleted: 'Deleted',
+      };
+    default:
+      return {
+        deleted: 'Slettet',
+      };
+  }
 };

--- a/lib/components/UserListItem/UserListItem.tsx
+++ b/lib/components/UserListItem/UserListItem.tsx
@@ -88,11 +88,21 @@ export const UserListItem = ({
 
   const deletedBadge = deleted ? (
     <div>
-      <Badge label={texts.deleted} color="neutral"/>
+      <Badge label={texts.deleted} color="neutral" />
     </div>
   ) : null;
 
-  return <ListItem icon={icon} ariaLabel={name} label={label} description={description} loading={loading} badge={deletedBadge} {...props} />;
+  return (
+    <ListItem
+      icon={icon}
+      ariaLabel={name}
+      label={label}
+      description={description}
+      loading={loading}
+      badge={deletedBadge}
+      {...props}
+    />
+  );
 };
 
 // TODO: Move to a common texts files when i18next is added

--- a/package.json
+++ b/package.json
@@ -2,17 +2,11 @@
   "name": "@altinn/altinn-components",
   "version": "0.68.17",
   "main": "dist/index.js",
-  "files": [
-    "dist/",
-    "!dist/stories/",
-    "!dist/components/*/*.stories.js"
-  ],
+  "files": ["dist/", "!dist/stories/", "!dist/components/*/*.stories.js"],
   "types": "dist/types/lib/index.d.ts",
   "type": "module",
   "description": "Reusable react components",
-  "sideEffects": [
-    "*.css"
-  ],
+  "sideEffects": ["*.css"],
   "scripts": {
     "test": "vitest run",
     "test:unit": "vitest run --project=unit",
@@ -98,11 +92,7 @@
   },
   "packageManager": "pnpm@10.15.1",
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "@biomejs/biome",
-      "@swc/core",
-      "esbuild"
-    ]
+    "onlyBuiltDependencies": ["@biomejs/biome", "@swc/core", "esbuild"]
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<img width="1258" height="316" alt="image" src="https://github.com/user-attachments/assets/6654520c-d586-4c75-9b13-cfd4e8196939" />

## Description
<!--- Describe your changes in detail -->
Added new badge that makes it more clear whether a user is deleted or not.
Before, only the avatar indicated if a user was deleted, but now, the UserListItem also uses badges, just like the items in the account list.

## Deploy 🚀

- [ ] Deploy Storybook preview
