### PR TITLE
chore(deps): harden pnpm against supply-chain attacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   "lint-staged": {
     "**/*.*": "biome check --staged --no-errors-on-unmatched --write"
   },
-  "packageManager": "pnpm@10.15.1",
+  "packageManager": "pnpm@10.34.5",
   "pnpm": {
     "onlyBuiltDependencies": [
       "@biomejs/biome",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+# Supply-chain hardening (requires pnpm >=10.21, see packageManager in package.json).
+# Delay installing newly published versions for 7 days so compromised releases
+# can be caught and unpublished before they reach us.
+minimumReleaseAge: 10080
+# Refuse packages whose trust signals (provenance, signatures) weaken between versions.
+trustPolicy: no-downgrade


### PR DESCRIPTION
Wait 7 days before installing newly published dependency versions, so compromised releases are caught and removed before they reach us. Also reject packages whose trust signals weaken between versions.
Bump pnpm to 10.34.5, since the old version ignored these settings.

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Deploy 🚀

- [ ] Deploy Storybook preview
