### PR TITLE
feat(consent): add useConsent hook and shared cookie contract

### DIFF
--- a/lib/components/SkyraSurvey/Consent.mdx
+++ b/lib/components/SkyraSurvey/Consent.mdx
@@ -1,0 +1,75 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Surveys and consent/Cookie consent" />
+
+# Cookie consent
+
+`useConsent` reads and writes the shared Altinn consent cookie. It resolves the environment's cookie domain
+itself, so an application never has to know about domains or the value format.
+
+Every instance shares one store, so a banner and the components gated by it stay in sync without a provider
+above them, including where there is no common React root.
+
+## Usage
+
+```tsx
+import { SkyraSurvey, useConsent } from "@altinn/altinn-components";
+
+const { consent, isAnswered, acceptAll, rejectAll } = useConsent();
+
+return (
+  <>
+    <SkyraSurvey consent={consent.statistics} />
+    {!isAnswered && <CookieBanner onAccept={acceptAll} onReject={rejectAll} />}
+  </>
+);
+```
+
+- `consent.statistics` — boolean, true only when granted. This is the one to gate on.
+- `status.statistics` — `granted`, `denied` or `unknown`. `unknown` means the user has not answered.
+- `isAnswered` — false until every category has an answer. Show the banner while it is false.
+- `setConsent({ statistics: true })` — answers specific categories. `acceptAll` and `rejectAll` cover the rest.
+- `clear()` — deletes the cookie, so nothing is answered and the banner comes back.
+
+A boolean cannot express all three states, which is why the banner is driven by `isAnswered` rather than by
+`consent`. Anything unanswered, malformed or stale reads as `unknown`, so an ambiguous cookie asks again
+instead of assuming an answer.
+
+## Withdrawing versus resetting
+
+These are different things, and a settings page usually wants the first.
+
+- **Withdraw consent** is `rejectAll()`, or `setConsent({ statistics: false })` for one category. It records a
+  denial: tracking stops, cookies set under the old answer should be cleaned up, and the user is not asked
+  again. This is what a "withdraw consent" control in a privacy page should do.
+- **Reset** is `clear()`. It deletes the cookie entirely, so the user counts as never having answered and the
+  banner appears on the next page view. Useful for a "ask me again" control and for testing.
+
+Reaching for `clear()` on a withdraw button means the banner returns on every visit, which is worse for the
+user and is not what withdrawing requires.
+
+`clear()` deletes the cookie at the two scopes this module writes, the environment's shared domain and
+host-only. It deliberately does not walk up to parent domains, so resetting in a test environment cannot
+remove the production answer. The consequence is that on a host under `tt02.altinn.no` a production cookie
+stays visible and the reset appears not to take.
+
+## The cookie
+
+- **Name** `altinn-consent`, on the environment's shared domain, so an answer given in one Altinn application
+  applies to the others.
+- **Value** a raw, unencoded query string, currently `v=1&statistics=granted`. Write it raw; a
+  percent-encoded value is still read, but only as a fallback for helpers that encode by default.
+- **Attributes** `Path=/`, `SameSite=Lax`, `Secure` over https, and a one year `Max-Age`. Not `HttpOnly`, so
+  it is a user preference and never an authorisation signal.
+- **Domain** `.altinn.no` in production, `.tt02.altinn.no`, `.at23.altinn.cloud` and `.yt01.altinn.cloud` in
+  test. The leading dot is legacy syntax, not a wildcard. Unrecognised hosts, including localhost and preview
+  deployments, get a host-only cookie.
+
+`v` is the policy version. A cookie written by an older version counts as unanswered, which is how a
+re-consent is forced. Unknown keys are ignored, so an application that adds a category does not invalidate
+the answer for the categories other applications already understand — adding a category is not a reason to
+bump `v`.
+
+Because a host in a test environment also matches the production domain, the same cookie name can appear
+twice with no way to tell which domain each value came from. Values that disagree resolve to the most
+restrictive one.

--- a/lib/components/SkyraSurvey/SkyraSurvey.mdx
+++ b/lib/components/SkyraSurvey/SkyraSurvey.mdx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="SkyraSurvey" />
+<Meta title="Surveys and consent/SkyraSurvey" />
 
 # Skyra surveys
 
@@ -15,13 +15,17 @@ browser refuses to execute the script if the bytes differ from the ones that wer
 Render it once, near the root of the app.
 
 ```tsx
-import { SkyraSurvey } from "@altinn/altinn-components";
+import { SkyraSurvey, useConsent } from "@altinn/altinn-components";
 
-<SkyraSurvey consent={cookieConsent.statistics} />;
+const { consent } = useConsent();
+
+<SkyraSurvey consent={consent.statistics} />;
 ```
 
 `consent` is the only required prop. Wire it to the statistics category of your cookie banner and let it
 follow changes, the component handles both a fresh click and a returning user who consented earlier.
+`useConsent` is the ready-made source for it, but any boolean works if your application already tracks
+consent itself.
 
 The script always loads; it is the cookies that are gated. Inline surveys and Findability work without
 consent. Popups do not, because they need a cookie to remember that a user has answered or dismissed them.

--- a/lib/functions/consent/consent.spec.ts
+++ b/lib/functions/consent/consent.spec.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CONSENT_COOKIE_NAME,
+  type ConsentState,
+  buildConsentCookie,
+  buildExpiredConsentCookie,
+  parseConsent,
+  resolveConsentDomain,
+  serializeConsent,
+} from './consent.ts';
+
+const cookie = (value: string): string => `${CONSENT_COOKIE_NAME}=${value}`;
+
+describe('parseConsent', () => {
+  it('reads a granted answer', () => {
+    expect(parseConsent(cookie('v=1&statistics=granted'))).toEqual({ statistics: 'granted' });
+  });
+
+  it('reads a denied answer', () => {
+    expect(parseConsent(cookie('v=1&statistics=denied'))).toEqual({ statistics: 'denied' });
+  });
+
+  it('finds the cookie among others', () => {
+    const cookies = `AltinnPartyId=123; ${cookie('v=1&statistics=granted')}; skyra.state=abc`;
+    expect(parseConsent(cookies)).toEqual({ statistics: 'granted' });
+  });
+
+  it('tolerates surrounding whitespace', () => {
+    expect(parseConsent(`  ${cookie('v=1&statistics=granted')}  `)).toEqual({ statistics: 'granted' });
+  });
+
+  it('requires an exact cookie name', () => {
+    expect(parseConsent(`not-${cookie('v=1&statistics=granted')}`)).toEqual({ statistics: 'unknown' });
+  });
+
+  it('is unknown when the cookie is missing', () => {
+    expect(parseConsent('skyra.state=abc')).toEqual({ statistics: 'unknown' });
+  });
+
+  it('is unknown for an empty, null or undefined cookie string', () => {
+    expect(parseConsent('')).toEqual({ statistics: 'unknown' });
+    expect(parseConsent(null)).toEqual({ statistics: 'unknown' });
+    expect(parseConsent(undefined)).toEqual({ statistics: 'unknown' });
+  });
+
+  it('is unknown when the category has no answer', () => {
+    expect(parseConsent(cookie('v=1'))).toEqual({ statistics: 'unknown' });
+  });
+
+  it('is unknown for an unrecognised status', () => {
+    expect(parseConsent(cookie('v=1&statistics=maybe'))).toEqual({ statistics: 'unknown' });
+  });
+
+  it('is unknown for a malformed value', () => {
+    expect(parseConsent(cookie('nonsense'))).toEqual({ statistics: 'unknown' });
+  });
+
+  it('is unknown when the version is missing', () => {
+    expect(parseConsent(cookie('statistics=granted'))).toEqual({ statistics: 'unknown' });
+  });
+
+  it('is unknown when the version is not a number', () => {
+    expect(parseConsent(cookie('v=one&statistics=granted'))).toEqual({ statistics: 'unknown' });
+  });
+
+  it('is unknown when the cookie predates the current policy version', () => {
+    expect(parseConsent(cookie('v=0&statistics=granted'))).toEqual({ statistics: 'unknown' });
+  });
+
+  it('reads a cookie written by a newer policy version', () => {
+    expect(parseConsent(cookie('v=2&statistics=granted'))).toEqual({ statistics: 'granted' });
+  });
+
+  it('ignores categories it does not know about', () => {
+    expect(parseConsent(cookie('v=2&statistics=granted&marketing=denied'))).toEqual({ statistics: 'granted' });
+  });
+
+  it('falls back to decoding a percent-encoded value', () => {
+    expect(parseConsent(cookie('v%3D1%26statistics%3Dgranted'))).toEqual({ statistics: 'granted' });
+  });
+
+  it('keeps the answer when duplicate cookies agree', () => {
+    const cookies = `${cookie('v=1&statistics=granted')}; ${cookie('v=1&statistics=granted')}`;
+    expect(parseConsent(cookies)).toEqual({ statistics: 'granted' });
+  });
+
+  it('takes the most restrictive answer when duplicate cookies disagree', () => {
+    const cookies = `${cookie('v=1&statistics=granted')}; ${cookie('v=1&statistics=denied')}`;
+    expect(parseConsent(cookies)).toEqual({ statistics: 'denied' });
+  });
+
+  it('re-asks when one of two duplicate cookies has no answer', () => {
+    const cookies = `${cookie('v=1&statistics=granted')}; ${cookie('v=1')}`;
+    expect(parseConsent(cookies)).toEqual({ statistics: 'unknown' });
+  });
+});
+
+describe('serializeConsent', () => {
+  it('writes a granted answer', () => {
+    expect(serializeConsent({ statistics: 'granted' })).toBe('v=1&statistics=granted');
+  });
+
+  it('writes a denied answer', () => {
+    expect(serializeConsent({ statistics: 'denied' })).toBe('v=1&statistics=denied');
+  });
+
+  it('leaves out categories without an answer', () => {
+    expect(serializeConsent({ statistics: 'unknown' })).toBe('v=1');
+  });
+
+  it('round-trips through parseConsent', () => {
+    const states: ConsentState[] = [{ statistics: 'granted' }, { statistics: 'denied' }, { statistics: 'unknown' }];
+    for (const state of states) {
+      expect(parseConsent(cookie(serializeConsent(state)))).toEqual(state);
+    }
+  });
+});
+
+// infoportal, arbeidsflate, amUI
+const applications = (environment: string) => [`info.${environment}`, `af.${environment}`, `am.ui.${environment}`];
+
+const resolveAll = (environment: string) => applications(environment).map(resolveConsentDomain);
+
+describe('resolveConsentDomain', () => {
+  it('shares one domain across the applications in production', () => {
+    expect(resolveAll('altinn.no')).toEqual(['.altinn.no', '.altinn.no', '.altinn.no']);
+  });
+
+  it('shares one domain across the applications in tt02', () => {
+    expect(resolveAll('tt02.altinn.no')).toEqual(['.tt02.altinn.no', '.tt02.altinn.no', '.tt02.altinn.no']);
+  });
+
+  it('shares one domain across the applications in the cloud environments', () => {
+    expect(resolveAll('at23.altinn.cloud')).toEqual(['.at23.altinn.cloud', '.at23.altinn.cloud', '.at23.altinn.cloud']);
+    expect(resolveAll('yt01.altinn.cloud')).toEqual(['.yt01.altinn.cloud', '.yt01.altinn.cloud', '.yt01.altinn.cloud']);
+  });
+
+  // The leak that matters: a tt02 host also matches the production domain, and writing there would
+  // carry a tester's answer into production.
+  it('never lets a tt02 host fall through to the production domain', () => {
+    for (const host of applications('tt02.altinn.no')) {
+      expect(resolveConsentDomain(host)).not.toBe('.altinn.no');
+    }
+  });
+
+  it('keeps the cloud environments apart from each other', () => {
+    expect(resolveConsentDomain('af.at23.altinn.cloud')).not.toBe(resolveConsentDomain('af.yt01.altinn.cloud'));
+  });
+
+  it('resolves the bare environment host', () => {
+    expect(resolveConsentDomain('altinn.no')).toBe('.altinn.no');
+    expect(resolveConsentDomain('tt02.altinn.no')).toBe('.tt02.altinn.no');
+    expect(resolveConsentDomain('at23.altinn.cloud')).toBe('.at23.altinn.cloud');
+  });
+
+  it('ignores case and a trailing root dot', () => {
+    expect(resolveConsentDomain('AM.UI.ALTINN.NO')).toBe('.altinn.no');
+    expect(resolveConsentDomain('af.altinn.no.')).toBe('.altinn.no');
+  });
+
+  it('matches on a label boundary, not a bare suffix', () => {
+    expect(resolveConsentDomain('notaltinn.no')).toBeUndefined();
+  });
+
+  it('is host-only for hosts it does not know', () => {
+    expect(resolveConsentDomain('localhost')).toBeUndefined();
+    expect(resolveConsentDomain('af.localhost')).toBeUndefined();
+    expect(resolveConsentDomain('altinn-components.pages.dev')).toBeUndefined();
+    // No entry for altinn.cloud itself, so a cloud host without an environment label is host-only.
+    expect(resolveConsentDomain('af.altinn.cloud')).toBeUndefined();
+  });
+});
+
+describe('buildConsentCookie', () => {
+  it('sets the shared domain for a known host', () => {
+    const result = buildConsentCookie({ statistics: 'granted' }, { hostname: 'af.altinn.no' });
+    expect(result).toBe(
+      'altinn-consent=v=1&statistics=granted; Path=/; Max-Age=31536000; SameSite=Lax; Domain=.altinn.no; Secure',
+    );
+  });
+
+  it('omits the domain for an unknown host', () => {
+    const result = buildConsentCookie({ statistics: 'denied' }, { hostname: 'localhost', secure: false });
+    expect(result).toBe('altinn-consent=v=1&statistics=denied; Path=/; Max-Age=31536000; SameSite=Lax');
+  });
+
+  it('omits the domain when no hostname is given', () => {
+    expect(buildConsentCookie({ statistics: 'granted' })).not.toContain('Domain=');
+  });
+});
+
+describe('buildExpiredConsentCookie', () => {
+  it('expires the cookie at the same domain and path it was written with', () => {
+    const written = buildConsentCookie({ statistics: 'granted' }, { hostname: 'af.altinn.no' });
+    const expired = buildExpiredConsentCookie({ hostname: 'af.altinn.no' });
+
+    expect(expired).toBe('altinn-consent=; Path=/; Max-Age=0; SameSite=Lax; Domain=.altinn.no; Secure');
+    for (const attribute of ['Path=/', 'Domain=.altinn.no', 'Secure']) {
+      expect(written).toContain(attribute);
+      expect(expired).toContain(attribute);
+    }
+  });
+
+  it('reads back as unanswered if a browser leaves an empty value behind', () => {
+    expect(parseConsent(cookie(''))).toEqual({ statistics: 'unknown' });
+  });
+});

--- a/lib/functions/consent/consent.ts
+++ b/lib/functions/consent/consent.ts
@@ -1,0 +1,178 @@
+export type ConsentCategory = 'statistics';
+
+export type ConsentStatus = 'granted' | 'denied' | 'unknown';
+
+export type ConsentState = Record<ConsentCategory, ConsentStatus>;
+
+export const CONSENT_CATEGORIES: readonly ConsentCategory[] = ['statistics'];
+
+export const CONSENT_COOKIE_NAME = 'altinn-consent';
+
+// Bump only to force a re-consent. Adding a category does not need one.
+export const CONSENT_VERSION = 1;
+
+export const CONSENT_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+// Longest match wins, so tt02 does not fall through to production. The leading dot is legacy
+// syntax, not a wildcard. Anything unmatched gets a host-only cookie, which covers localhost.
+const CONSENT_DOMAINS = ['.at23.altinn.cloud', '.yt01.altinn.cloud', '.tt02.altinn.no', '.altinn.no'];
+
+const buildState = (resolve: (category: ConsentCategory) => ConsentStatus): ConsentState => {
+  return Object.fromEntries(CONSENT_CATEGORIES.map((category) => [category, resolve(category)])) as ConsentState;
+};
+
+export const UNKNOWN_CONSENT: ConsentState = Object.freeze(buildState(() => 'unknown'));
+
+const RESTRICTIVENESS: Record<ConsentStatus, number> = { denied: 2, unknown: 1, granted: 0 };
+
+const parsePairs = (value: string): Map<string, string> => {
+  const pairs = new Map<string, string>();
+  for (const part of value.split('&')) {
+    const separator = part.indexOf('=');
+    if (separator < 1) {
+      continue;
+    }
+    pairs.set(part.slice(0, separator), part.slice(separator + 1));
+  }
+  return pairs;
+};
+
+// We write raw, but js-cookie and friends percent-encode by default. Tolerate both.
+const parseValue = (raw: string): Map<string, string> => {
+  const direct = parsePairs(raw);
+  if (direct.has('v') || !raw.includes('%')) {
+    return direct;
+  }
+  try {
+    return parsePairs(decodeURIComponent(raw));
+  } catch {
+    return direct;
+  }
+};
+
+const toStatus = (value: string | undefined): ConsentStatus => {
+  if (value === 'granted') {
+    return 'granted';
+  }
+  if (value === 'denied') {
+    return 'denied';
+  }
+  return 'unknown';
+};
+
+const readCookieValues = (cookieString: string): string[] => {
+  const values: string[] = [];
+  for (const part of cookieString.split(';')) {
+    const entry = part.trim();
+    const separator = entry.indexOf('=');
+    if (separator < 1 || entry.slice(0, separator) !== CONSENT_COOKIE_NAME) {
+      continue;
+    }
+    values.push(entry.slice(separator + 1));
+  }
+  return values;
+};
+
+const parseCookieValue = (raw: string): ConsentState => {
+  const pairs = parseValue(raw);
+  const version = Number(pairs.get('v'));
+  if (!Number.isInteger(version) || version < CONSENT_VERSION) {
+    return UNKNOWN_CONSENT;
+  }
+  return buildState((category) => toStatus(pairs.get(category)));
+};
+
+// Takes document.cookie or a request's Cookie header. The name can appear twice, since a tt02 host
+// also matches the production domain and document.cookie hides which domain a value came from, so
+// values that disagree resolve to the most restrictive.
+export const parseConsent = (cookieString: string | null | undefined): ConsentState => {
+  const values = readCookieValues(cookieString ?? '');
+  if (values.length === 0) {
+    return UNKNOWN_CONSENT;
+  }
+  const states = values.map(parseCookieValue);
+  return buildState((category) =>
+    states.reduce<ConsentStatus>((winner, state) => {
+      const status = state[category];
+      return RESTRICTIVENESS[status] > RESTRICTIVENESS[winner] ? status : winner;
+    }, 'granted'),
+  );
+};
+
+export const serializeConsent = (state: ConsentState): string => {
+  const parts = [`v=${CONSENT_VERSION}`];
+  for (const category of CONSENT_CATEGORIES) {
+    const status = state[category];
+    if (status !== 'unknown') {
+      parts.push(`${category}=${status}`);
+    }
+  }
+  return parts.join('&');
+};
+
+export const resolveConsentDomain = (hostname: string): string | undefined => {
+  const host = hostname.trim().toLowerCase().replace(/\.$/, '');
+  let match: string | undefined;
+  for (const domain of CONSENT_DOMAINS) {
+    const bare = domain.slice(1);
+    if (host !== bare && !host.endsWith(`.${bare}`)) {
+      continue;
+    }
+    if (!match || domain.length > match.length) {
+      match = domain;
+    }
+  }
+  return match;
+};
+
+export interface ConsentCookieOptions {
+  hostname?: string;
+  secure?: boolean;
+}
+
+const buildCookie = (value: string, maxAge: number, options: ConsentCookieOptions): string => {
+  const { hostname, secure = true } = options;
+  const attributes = [`${CONSENT_COOKIE_NAME}=${value}`, 'Path=/', `Max-Age=${maxAge}`, 'SameSite=Lax'];
+  const domain = hostname ? resolveConsentDomain(hostname) : undefined;
+  if (domain) {
+    attributes.push(`Domain=${domain}`);
+  }
+  if (secure) {
+    attributes.push('Secure');
+  }
+  return attributes.join('; ');
+};
+
+export const buildConsentCookie = (state: ConsentState, options: ConsentCookieOptions = {}): string => {
+  return buildCookie(serializeConsent(state), CONSENT_MAX_AGE_SECONDS, options);
+};
+
+// A deletion only lands when domain and path match the write, hence the shared builder.
+export const buildExpiredConsentCookie = (options: ConsentCookieOptions = {}): string => {
+  return buildCookie('', 0, options);
+};
+
+export const isSameConsent = (a: ConsentState, b: ConsentState): boolean => {
+  return CONSENT_CATEGORIES.every((category) => a[category] === b[category]);
+};
+
+export const writeConsentCookie = (state: ConsentState): void => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  document.cookie = buildConsentCookie(state, {
+    hostname: document.location?.hostname,
+    secure: document.location?.protocol === 'https:',
+  });
+};
+
+// Both scopes we write, and no further: walking up to parent domains would let a reset in tt02
+// wipe the production answer.
+export const deleteConsentCookie = (): void => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  const secure = document.location?.protocol === 'https:';
+  document.cookie = buildExpiredConsentCookie({ hostname: document.location?.hostname, secure });
+  document.cookie = buildExpiredConsentCookie({ secure });
+};

--- a/lib/functions/consent/consentStore.spec.ts
+++ b/lib/functions/consent/consentStore.spec.ts
@@ -1,0 +1,368 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type * as ConsentStoreModule from './consentStore.ts';
+
+// Matches CONSENT_STORE_KEY. Referenced by value so the singleton can be cleared between tests.
+const STORE_KEY = Symbol.for('altinn-components.consent-store');
+
+const GRANTED = 'altinn-consent=v=1&statistics=granted';
+const DENIED = 'altinn-consent=v=1&statistics=denied';
+
+const createEventRegistry = () => {
+  const listeners = new Map<string, Set<() => void>>();
+  return {
+    addEventListener: (type: string, listener: () => void) => {
+      const existing = listeners.get(type) ?? new Set<() => void>();
+      existing.add(listener);
+      listeners.set(type, existing);
+    },
+    removeEventListener: (type: string, listener: () => void) => {
+      listeners.get(type)?.delete(listener);
+    },
+    dispatch: (type: string) => {
+      for (const listener of [...(listeners.get(type) ?? [])]) {
+        listener();
+      }
+    },
+    count: (type: string) => listeners.get(type)?.size ?? 0,
+  };
+};
+
+const define = (property: string, value: unknown) => {
+  Object.defineProperty(globalThis, property, { value, configurable: true, writable: true });
+};
+
+interface FakeEnvironmentOptions {
+  hostname?: string;
+  blocked?: boolean;
+  seed?: string;
+}
+
+const useFakeEnvironment = ({ hostname = 'localhost', blocked = false, seed }: FakeEnvironmentOptions = {}) => {
+  const jar = new Map<string, string>();
+  if (seed) {
+    const separator = seed.indexOf('=');
+    jar.set(seed.slice(0, separator), seed.slice(separator + 1));
+  }
+  const documentEvents = createEventRegistry();
+  const globalEvents = createEventRegistry();
+
+  const fakeDocument = {
+    get cookie(): string {
+      return [...jar.entries()].map(([name, value]) => `${name}=${value}`).join('; ');
+    },
+    set cookie(raw: string) {
+      if (blocked) {
+        return;
+      }
+      const [pair, ...attributes] = raw.split(';');
+      const separator = pair.indexOf('=');
+      const name = pair.slice(0, separator).trim();
+      if (attributes.some((attribute) => attribute.trim().toLowerCase() === 'max-age=0')) {
+        jar.delete(name);
+        return;
+      }
+      jar.set(name, pair.slice(separator + 1));
+    },
+    visibilityState: 'visible',
+    location: { hostname, protocol: 'http:' },
+    addEventListener: documentEvents.addEventListener,
+    removeEventListener: documentEvents.removeEventListener,
+  };
+
+  define('document', fakeDocument);
+  define('addEventListener', globalEvents.addEventListener);
+  define('removeEventListener', globalEvents.removeEventListener);
+
+  return { document: fakeDocument, documentEvents, globalEvents };
+};
+
+// Fresh store per test: the singleton outlives vi.resetModules().
+const loadStore = async (): Promise<typeof ConsentStoreModule> => {
+  Reflect.deleteProperty(globalThis, STORE_KEY);
+  vi.resetModules();
+  return import('./consentStore.ts');
+};
+
+afterEach(() => {
+  for (const property of ['document', 'addEventListener', 'removeEventListener']) {
+    Reflect.deleteProperty(globalThis, property);
+  }
+  Reflect.deleteProperty(globalThis, STORE_KEY);
+  vi.restoreAllMocks();
+});
+
+describe('consentStore', () => {
+  it('starts unanswered', async () => {
+    useFakeEnvironment();
+    const { readConsent } = await loadStore();
+    expect(readConsent()).toEqual({ statistics: 'unknown' });
+  });
+
+  it('writes the cookie and notifies subscribers', async () => {
+    const { document } = useFakeEnvironment();
+    const { readConsent, setConsent, subscribeConsent } = await loadStore();
+    const listener = vi.fn();
+    subscribeConsent(listener);
+
+    setConsent({ statistics: true });
+
+    expect(document.cookie).toContain(GRANTED);
+    expect(readConsent()).toEqual({ statistics: 'granted' });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('scopes the cookie to the environment domain', async () => {
+    const { document } = useFakeEnvironment({ hostname: 'af.tt02.altinn.no' });
+    const { setConsent } = await loadStore();
+    const spy = vi.spyOn(document, 'cookie', 'set');
+
+    setConsent({ statistics: false });
+
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('Domain=.tt02.altinn.no'));
+  });
+
+  it('keeps a stable snapshot reference while the cookie is unchanged', async () => {
+    useFakeEnvironment();
+    const { readConsent, setConsent } = await loadStore();
+    setConsent({ statistics: true });
+
+    expect(readConsent()).toBe(readConsent());
+  });
+
+  it('keeps the snapshot reference when an unrelated cookie changes', async () => {
+    const { document } = useFakeEnvironment();
+    const { readConsent, setConsent } = await loadStore();
+    setConsent({ statistics: true });
+    const before = readConsent();
+
+    document.cookie = 'skyra.state=abc';
+
+    expect(readConsent()).toBe(before);
+  });
+
+  it('does not notify when an answer is repeated', async () => {
+    useFakeEnvironment();
+    const { setConsent, subscribeConsent } = await loadStore();
+    setConsent({ statistics: true });
+    const listener = vi.fn();
+    subscribeConsent(listener);
+
+    setConsent({ statistics: true });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('stops notifying after unsubscribe', async () => {
+    useFakeEnvironment();
+    const { setConsent, subscribeConsent } = await loadStore();
+    const listener = vi.fn();
+    const unsubscribe = subscribeConsent(listener);
+    unsubscribe();
+
+    setConsent({ statistics: true });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('answers every category through acceptAll and rejectAll', async () => {
+    useFakeEnvironment();
+    const { acceptAllConsent, readConsent, rejectAllConsent } = await loadStore();
+
+    acceptAllConsent();
+    expect(readConsent()).toEqual({ statistics: 'granted' });
+
+    rejectAllConsent();
+    expect(readConsent()).toEqual({ statistics: 'denied' });
+  });
+
+  it('clears the answer and notifies, so the banner is shown again', async () => {
+    const { document } = useFakeEnvironment();
+    const { clearConsent, readConsent, setConsent, subscribeConsent } = await loadStore();
+    setConsent({ statistics: true });
+    const listener = vi.fn();
+    subscribeConsent(listener);
+
+    clearConsent();
+
+    expect(document.cookie).not.toContain('altinn-consent');
+    expect(readConsent()).toEqual({ statistics: 'unknown' });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves other cookies alone when clearing', async () => {
+    const { document } = useFakeEnvironment({ seed: 'skyra.state=abc' });
+    const { clearConsent, setConsent } = await loadStore();
+    setConsent({ statistics: true });
+
+    clearConsent();
+
+    expect(document.cookie).toContain('skyra.state=abc');
+  });
+
+  it('clears at both the shared domain and host-only scope', async () => {
+    const { document } = useFakeEnvironment({ hostname: 'af.tt02.altinn.no' });
+    const { clearConsent, setConsent } = await loadStore();
+    setConsent({ statistics: true });
+    const spy = vi.spyOn(document, 'cookie', 'set');
+
+    clearConsent();
+
+    const written = spy.mock.calls.map(([value]) => value as string);
+    expect(written).toHaveLength(2);
+    expect(written[0]).toContain('Domain=.tt02.altinn.no');
+    expect(written[0]).toContain('Max-Age=0');
+    expect(written[1]).not.toContain('Domain=');
+  });
+
+  it('does nothing when there is no answer to clear', async () => {
+    useFakeEnvironment();
+    const { clearConsent, subscribeConsent } = await loadStore();
+    const listener = vi.fn();
+    subscribeConsent(listener);
+
+    clearConsent();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('is inert when clearing without a document', async () => {
+    Reflect.deleteProperty(globalThis, 'document');
+    const { clearConsent } = await loadStore();
+
+    expect(() => clearConsent()).not.toThrow();
+  });
+
+  it('reports when the cookie could not be stored', async () => {
+    useFakeEnvironment({ blocked: true });
+    const { readConsent, setConsent } = await loadStore();
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    setConsent({ statistics: true });
+
+    expect(readConsent()).toEqual({ statistics: 'unknown' });
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('cookies may be blocked'));
+  });
+
+  it('is unanswered and inert without a document', async () => {
+    Reflect.deleteProperty(globalThis, 'document');
+    const { readConsent, setConsent } = await loadStore();
+
+    expect(() => setConsent({ statistics: true })).not.toThrow();
+    expect(readConsent()).toEqual({ statistics: 'unknown' });
+  });
+});
+
+// No cookie change event exists, so returning to the page is the only signal.
+describe('consentStore change detection', () => {
+  it('picks up a cookie written elsewhere on an explicit refresh', async () => {
+    const { document } = useFakeEnvironment();
+    const { readConsent, refreshConsent, subscribeConsent } = await loadStore();
+    const listener = vi.fn();
+    subscribeConsent(listener);
+
+    document.cookie = DENIED;
+    refreshConsent();
+
+    expect(readConsent()).toEqual({ statistics: 'denied' });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not notify when a refresh finds no change', async () => {
+    useFakeEnvironment();
+    const { refreshConsent, setConsent, subscribeConsent } = await loadStore();
+    setConsent({ statistics: true });
+    const listener = vi.fn();
+    subscribeConsent(listener);
+
+    refreshConsent();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('re-reads when the window regains focus', async () => {
+    const { document, globalEvents } = useFakeEnvironment();
+    const { readConsent, subscribeConsent } = await loadStore();
+    const listener = vi.fn();
+    subscribeConsent(listener);
+
+    document.cookie = GRANTED;
+    globalEvents.dispatch('focus');
+
+    expect(readConsent()).toEqual({ statistics: 'granted' });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-reads when the tab becomes visible', async () => {
+    const { document, documentEvents } = useFakeEnvironment();
+    const { readConsent, subscribeConsent } = await loadStore();
+    const listener = vi.fn();
+    subscribeConsent(listener);
+
+    document.cookie = DENIED;
+    documentEvents.dispatch('visibilitychange');
+
+    expect(readConsent()).toEqual({ statistics: 'denied' });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores visibilitychange while the tab is hidden', async () => {
+    const { document, documentEvents } = useFakeEnvironment();
+    const { subscribeConsent } = await loadStore();
+    const listener = vi.fn();
+    subscribeConsent(listener);
+
+    document.visibilityState = 'hidden';
+    document.cookie = GRANTED;
+    documentEvents.dispatch('visibilitychange');
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('re-reads on a back navigation restored from the bfcache', async () => {
+    const { document, globalEvents } = useFakeEnvironment();
+    const { readConsent, subscribeConsent } = await loadStore();
+    const listener = vi.fn();
+    subscribeConsent(listener);
+
+    // The page never went hidden and the window never lost focus, so pageshow is the only signal.
+    document.cookie = GRANTED;
+    globalEvents.dispatch('pageshow');
+
+    expect(readConsent()).toEqual({ statistics: 'granted' });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('notifies once when several signals arrive for the same change', async () => {
+    const { document, documentEvents, globalEvents } = useFakeEnvironment();
+    const { subscribeConsent } = await loadStore();
+    const listener = vi.fn();
+    subscribeConsent(listener);
+
+    document.cookie = GRANTED;
+    globalEvents.dispatch('pageshow');
+    globalEvents.dispatch('focus');
+    documentEvents.dispatch('visibilitychange');
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('attaches listeners once and detaches them with the last subscriber', async () => {
+    const { documentEvents, globalEvents } = useFakeEnvironment();
+    const { subscribeConsent } = await loadStore();
+
+    const first = subscribeConsent(vi.fn());
+    const second = subscribeConsent(vi.fn());
+
+    expect(globalEvents.count('focus')).toBe(1);
+    expect(globalEvents.count('pageshow')).toBe(1);
+    expect(documentEvents.count('visibilitychange')).toBe(1);
+
+    first();
+    expect(globalEvents.count('focus')).toBe(1);
+
+    second();
+    expect(globalEvents.count('focus')).toBe(0);
+    expect(globalEvents.count('pageshow')).toBe(0);
+    expect(documentEvents.count('visibilitychange')).toBe(0);
+  });
+});

--- a/lib/functions/consent/consentStore.ts
+++ b/lib/functions/consent/consentStore.ts
@@ -1,0 +1,170 @@
+'use client';
+import {
+  CONSENT_CATEGORIES,
+  type ConsentCategory,
+  type ConsentState,
+  UNKNOWN_CONSENT,
+  deleteConsentCookie,
+  isSameConsent,
+  parseConsent,
+  writeConsentCookie,
+} from './consent.ts';
+
+export type ConsentChanges = Partial<Record<ConsentCategory, boolean>>;
+
+export interface ConsentStore {
+  getSnapshot: () => ConsentState;
+  subscribe: (listener: () => void) => () => void;
+  set: (changes: ConsentChanges) => void;
+  clear: () => void;
+  refresh: () => void;
+}
+
+// On the global rather than in module scope: a page can end up with two copies of this module, and
+// two stores would disagree about consent.
+const CONSENT_STORE_KEY = Symbol.for('altinn-components.consent-store');
+
+const createConsentStore = (): ConsentStore => {
+  const listeners = new Set<() => void>();
+  let snapshot: ConsentState = UNKNOWN_CONSENT;
+  let lastCookie: string | null = null;
+  let detach: (() => void) | undefined;
+
+  const read = (): ConsentState => {
+    if (typeof document === 'undefined') {
+      return snapshot;
+    }
+    const cookie = document.cookie;
+    if (cookie === lastCookie) {
+      return snapshot;
+    }
+    lastCookie = cookie;
+    const next = parseConsent(cookie);
+    if (!isSameConsent(next, snapshot)) {
+      snapshot = next;
+    }
+    return snapshot;
+  };
+
+  const notify = (): void => {
+    for (const listener of listeners) {
+      listener();
+    }
+  };
+
+  const refresh = (): void => {
+    const previous = snapshot;
+    if (read() !== previous) {
+      notify();
+    }
+  };
+
+  const attach = (): void => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        refresh();
+      }
+    };
+    // A cookie changed elsewhere: another tab, or another application on the domain. `pageshow`
+    // catches a back navigation from the bfcache, where the other two do not fire.
+    globalThis.addEventListener('focus', refresh);
+    globalThis.addEventListener('pageshow', refresh);
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    detach = () => {
+      globalThis.removeEventListener('focus', refresh);
+      globalThis.removeEventListener('pageshow', refresh);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  };
+
+  const subscribe = (listener: () => void): (() => void) => {
+    listeners.add(listener);
+    if (listeners.size === 1) {
+      attach();
+    }
+    return () => {
+      listeners.delete(listener);
+      if (listeners.size === 0) {
+        detach?.();
+        detach = undefined;
+      }
+    };
+  };
+
+  const set = (changes: ConsentChanges): void => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+    const previous = read();
+    const next: ConsentState = { ...previous };
+    for (const category of CONSENT_CATEGORIES) {
+      const value = changes[category];
+      if (value !== undefined) {
+        next[category] = value ? 'granted' : 'denied';
+      }
+    }
+
+    // Written even when nothing changed, so answering again renews the expiry.
+    writeConsentCookie(next);
+    lastCookie = null;
+
+    if (read() !== previous) {
+      notify();
+      return;
+    }
+    if (!isSameConsent(next, previous)) {
+      console.error('[consent] Consent could not be stored, cookies may be blocked');
+    }
+  };
+
+  const clear = (): void => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+    const previous = read();
+    deleteConsentCookie();
+    lastCookie = null;
+
+    if (read() !== previous) {
+      notify();
+    }
+  };
+
+  return { getSnapshot: read, subscribe, set, clear, refresh };
+};
+
+const resolveConsentStore = (): ConsentStore => {
+  const registry = globalThis as unknown as Record<symbol, ConsentStore | undefined>;
+  const existing = registry[CONSENT_STORE_KEY];
+  if (existing) {
+    return existing;
+  }
+  const created = createConsentStore();
+  registry[CONSENT_STORE_KEY] = created;
+  return created;
+};
+
+export const consentStore: ConsentStore = resolveConsentStore();
+
+const everyCategory = (value: boolean): ConsentChanges => {
+  return Object.fromEntries(CONSENT_CATEGORIES.map((category) => [category, value])) as ConsentChanges;
+};
+
+export const readConsent = (): ConsentState => consentStore.getSnapshot();
+
+export const subscribeConsent = (listener: () => void): (() => void) => consentStore.subscribe(listener);
+
+export const setConsent = (changes: ConsentChanges): void => consentStore.set(changes);
+
+export const acceptAllConsent = (): void => consentStore.set(everyCategory(true));
+
+export const rejectAllConsent = (): void => consentStore.set(everyCategory(false));
+
+// Not the same as withdrawing consent: this makes the banner come back.
+export const clearConsent = (): void => consentStore.clear();
+
+export const refreshConsent = (): void => consentStore.refresh();

--- a/lib/functions/consent/index.ts
+++ b/lib/functions/consent/index.ts
@@ -1,0 +1,2 @@
+export * from './consent.ts';
+export * from './consentStore.ts';

--- a/lib/functions/index.ts
+++ b/lib/functions/index.ts
@@ -1,3 +1,4 @@
 export * from './name';
 export * from './date';
 export * from './orgno';
+export * from './consent';

--- a/lib/hooks/index.ts
+++ b/lib/hooks/index.ts
@@ -2,3 +2,4 @@ export * from './useClickOutside';
 export * from './useEscapeKey';
 export * from './useMenu';
 export * from './useAccountSelector';
+export * from './useConsent';

--- a/lib/hooks/useConsent.ts
+++ b/lib/hooks/useConsent.ts
@@ -1,0 +1,49 @@
+'use client';
+import { useCallback, useMemo, useSyncExternalStore } from 'react';
+import {
+  CONSENT_CATEGORIES,
+  type ConsentCategory,
+  type ConsentChanges,
+  type ConsentState,
+  UNKNOWN_CONSENT,
+  acceptAllConsent,
+  clearConsent,
+  consentStore,
+  rejectAllConsent,
+} from '../functions';
+
+export interface UseConsentResult {
+  status: ConsentState;
+  /** True only when granted. Gate on this rather than on status. */
+  consent: Record<ConsentCategory, boolean>;
+  /** False until every category has an answer. Show the banner while it is false. */
+  isAnswered: boolean;
+  setConsent: (changes: ConsentChanges) => void;
+  acceptAll: () => void;
+  rejectAll: () => void;
+  /** Deletes the cookie so the user is asked again. To stop tracking instead, use rejectAll. */
+  clear: () => void;
+}
+
+const getServerSnapshot = (): ConsentState => UNKNOWN_CONSENT;
+
+export const useConsent = (): UseConsentResult => {
+  const status = useSyncExternalStore(consentStore.subscribe, consentStore.getSnapshot, getServerSnapshot);
+
+  const consent = useMemo(() => {
+    return Object.fromEntries(
+      CONSENT_CATEGORIES.map((category) => [category, status[category] === 'granted']),
+    ) as Record<ConsentCategory, boolean>;
+  }, [status]);
+
+  const isAnswered = useMemo(() => {
+    return CONSENT_CATEGORIES.every((category) => status[category] !== 'unknown');
+  }, [status]);
+
+  const setConsent = useCallback((changes: ConsentChanges) => consentStore.set(changes), []);
+  const acceptAll = useCallback(() => acceptAllConsent(), []);
+  const rejectAll = useCallback(() => rejectAllConsent(), []);
+  const clear = useCallback(() => clearConsent(), []);
+
+  return { status, consent, isAnswered, setConsent, acceptAll, rejectAll, clear };
+};


### PR DESCRIPTION
Adds `useConsent` for reading and writing the shared Altinn consent cookie, so applications don't have to know about cookie domains or the value format. 

The cookie is `altinn-consent`, scoped from the hostname to the environment's shared domain (`.altinn.no`, `.tt02.altinn.no`, `.at23.altinn.cloud`), so consent given in arbeidsflate is read by infoportal and amUI with and vice versa.

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
https://github.com/Altinn/altinn-components/issues/1340

## Deploy 🚀

- [x] Deploy Storybook preview
